### PR TITLE
Implementing inline mode

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -35,6 +35,7 @@
 #include "tgbot/types/InputFile.h"
 #include "tgbot/types/UserProfilePhotos.h"
 #include "tgbot/types/Update.h"
+#include "tgbot/types/InlineQueryResult.h"
 
 namespace TgBot {
 
@@ -229,7 +230,20 @@ public:
 	 * Ports currently supported for Webhooks: 443, 80, 88, 8443.
 	 * @param url Optional. HTTPS url to send updates to. Use an empty string to remove webhook integration.
 	 */
+	// TODO Add support to self-signed certificate
 	void setWebhook(const std::string& url = "") const;
+
+	/**
+	 * Use this method to send answers to an inline query.
+	 * No mode that 50 results per query are allowed.
+	 * @param inlineQueryId Unique identifier for the answered query.
+	 * @param results Array of results for the inline query.
+	 * @param cacheTime The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
+	 * @param isPersonal Pass True, if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query.
+	 * @param nextOffset Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
+	 */
+	void answerInlineQuery(const std::string inlineQueryId, const std::vector<InlineQueryResult::Ptr> results,
+							int32_t cacheTime=300, bool isPersonal=false, const std::string& nextOffset="");
 
 private:
 	boost::property_tree::ptree sendRequest(const std::string& method, const std::vector<HttpReqArg>& args = std::vector<HttpReqArg>()) const;

--- a/include/tgbot/EventHandler.h
+++ b/include/tgbot/EventHandler.h
@@ -31,34 +31,44 @@ namespace TgBot {
 
 class EventHandler {
 
+	inline void handleMessage(const Message::Ptr& message){
+		_broadcaster->broadcastAnyMessage(update->message);
+
+		if (StringTools::startsWith(message->text, "/")) {
+			unsigned long splitPosition;
+			unsigned long spacePosition = message->text.find(' ');
+			unsigned long atSymbolPosition = message->text.find('@');
+			if (spacePosition == message->text.npos) {
+				if (atSymbolPosition == message->text.npos) {
+					splitPosition = message->text.size();
+				} else {
+					splitPosition = atSymbolPosition;
+				}
+			} else if (atSymbolPosition == message->text.npos) {
+				splitPosition = spacePosition;
+			} else {
+				splitPosition = std::min(spacePosition, atSymbolPosition);
+			}
+			std::string command = message->text.substr(1, splitPosition - 1);
+			if (!_broadcaster->broadcastCommand(command, message)) {
+				_broadcaster->broadcastUnknownCommand(message);
+			}
+		} else {
+			_broadcaster->broadcastNonCommandMessage(message);
+		}
+	};
+
 public:
 	explicit EventHandler(const EventBroadcaster* broadcaster) : _broadcaster(broadcaster) {
 	}
 
 	inline void handleUpdate(const Update::Ptr& update) const {
-		_broadcaster->broadcastAnyMessage(update->message);
-		if (StringTools::startsWith(update->message->text, "/")) {
-			unsigned long splitPosition;
-			unsigned long spacePosition = update->message->text.find(' ');
-			unsigned long atSymbolPosition = update->message->text.find('@');
-			if (spacePosition == update->message->text.npos) {
-				if (atSymbolPosition == update->message->text.npos) {
-					splitPosition = update->message->text.size();
-				} else {
-					splitPosition = atSymbolPosition;
-				}
-			} else if (atSymbolPosition == update->message->text.npos) {
-				splitPosition = spacePosition;
-			} else {
-				splitPosition = std::min(spacePosition, atSymbolPosition);
-			}
-			std::string command = update->message->text.substr(1, splitPosition - 1);
-			if (!_broadcaster->broadcastCommand(command, update->message)) {
-				_broadcaster->broadcastUnknownCommand(update->message);
-			}
-		} else {
-			_broadcaster->broadcastNonCommandMessage(update->message);
-		}
+		if (update->inlineQuery != NULL)
+			_broadcaster->broadcastInlineQuery(update->inlineQuery);
+		if (update->chosenInlineResult != NULL)
+			_broadcaster->broadcastChosenInlineResult(update->chosenInlineResult);
+		if (update->message != NULL)
+			handleMessag(update->message);
 	}
 
 private:

--- a/include/tgbot/TgTypeParser.h
+++ b/include/tgbot/TgTypeParser.h
@@ -44,6 +44,14 @@
 #include "tgbot/types/ReplyKeyboardHide.h"
 #include "tgbot/types/ForceReply.h"
 #include "tgbot/types/GenericReply.h"
+#include "tgbot/types/InlineQuery.h"
+#include "tgbot/types/InlineQueryResult.h"
+#include "tgbot/types/InlineQueryResultArticle.h"
+#include "tgbot/types/InlineQueryResultPhoto.h"
+#include "tgbot/types/InlineQueryResultGif.h"
+#include "tgbot/types/InlineQueryResultMpeg4Gif.h"
+#include "tgbot/types/InlineQueryResultVideo.h"
+#include "tgbot/types/ChosenInlineResult.h"
 
 namespace TgBot {
 
@@ -90,6 +98,22 @@ public:
 	std::string parseForceReply(const ForceReply::Ptr& object) const;
 	GenericReply::Ptr parseJsonAndGetGenericReply(const boost::property_tree::ptree& data) const;
 	std::string parseGenericReply(const GenericReply::Ptr& object) const;
+	InlineQuery::Ptr parseJsonAndGetInlineQuery(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQuery(const InlineQuery::Ptr& object) const;
+	InlineQueryResult::Ptr parseJsonAndGetInlineQueryResult(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResult(const InlineQueryResult::Ptr& object) const;
+	InlineQueryResultArticle::Ptr parseJsonAndGetInlineQueryResultArticle(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResultArticle(const InlineQueryResultArticle::Ptr& object) const;
+	InlineQueryResultPhoto::Ptr parseJsonAndGetInlineQueryResultPhoto(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResultPhoto(const InlineQueryResultPhoto::Ptr& object) const;
+	InlineQueryResultGif::Ptr parseJsonAndGetInlineQueryResultGif(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResultGif(const InlineQueryResultGif::Ptr& object) const;
+	InlineQueryResultMpeg4Gif::Ptr parseJsonAndGetInlineQueryResultMpeg4Gif(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResultMpeg4Gif(const InlineQueryResultMpeg4Gif::Ptr& object) const;
+	InlineQueryResultVideo::Ptr parseJsonAndGetInlineQueryResultVideo(const boost::property_tree::ptree& data) const;
+	std::string parseInlineQueryResultVideo(const InlineQueryResultVideo::Ptr& object) const;
+	ChosenInlineResult::Ptr parseJsonAndGetChosenInlineResult(const boost::property_tree::ptree& data) const;
+	std::string parseChosenInlineResult(const ChosenInlineResult::Ptr& object) const;
 
 	inline boost::property_tree::ptree parseJson(const std::string& json) const {
 		boost::property_tree::ptree tree;

--- a/include/tgbot/net/HttpReqArg.h
+++ b/include/tgbot/net/HttpReqArg.h
@@ -24,6 +24,7 @@
 #define TGBOT_HTTPPARAMETER_H
 
 #include <string>
+#include <vector>
 
 #include <boost/lexical_cast.hpp>
 
@@ -40,6 +41,22 @@ public:
 	HttpReqArg(const std::string& name, const T& value, bool isFile = false, const std::string& mimeType = "text/plain", const std::string& fileName = "") :
 			name(name), value(boost::lexical_cast<std::string>(value)), isFile(isFile), mimeType(mimeType), fileName(fileName)
 	{
+	}
+
+	template<typename T>
+	HttpReqArg(const std::string& name, const std::vector<T>& list, function<std::string (const T&)> parsingFunction){
+		this->name = name;
+		value = "[";
+		for (const T& item : list){
+			value += parsingFunction(item);
+			value += ',';
+		}
+		value.erase(this->value.length() - 1);
+		value += ']';
+
+		isFile = false;
+		mimeType = "text/plain";
+		fileName = "";
 	}
 
 	/**

--- a/include/tgbot/types/ChosenInlineResult.h
+++ b/include/tgbot/types/ChosenInlineResult.h
@@ -1,0 +1,40 @@
+//
+// Created by Andrea Giove on 27/03/16.
+//
+
+#ifndef TGBOT_CHOSENINLINERESULT_H
+#define TGBOT_CHOSENINLINERESULT_H
+
+#include <string>
+#include <memory>
+
+#include "tgbot/types/User.h"
+
+namespace TgBot {
+
+/**
+ * This object represents a result of an inline query that was chosen by the user and sent to their chat partner.
+ * @ingroup types
+ */
+class ChosenInlineResult {
+public:
+	typedef std::shared_ptr<ChosenInlineResult> Ptr;
+
+	/**
+	 * The unique identifier for the result that was chosen.
+	 */
+	std::string resultId;
+
+	/**
+	 * The user that chose the result.
+	 */
+	User::Ptr user;
+
+	/**
+	 * The query that was used to obtain the result.
+	 */
+	std::string query;
+};
+}
+
+#endif //TGBOT_CHOSENINLINERESULT_H

--- a/include/tgbot/types/InlineQuery.h
+++ b/include/tgbot/types/InlineQuery.h
@@ -1,0 +1,46 @@
+//
+// Created by Andrea Giove on 26/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERY_H
+#define TGBOT_INLINEQUERY_H
+
+#include <memory>
+#include <string>
+
+#include "tgbot/types/User.h"
+
+namespace TgBot {
+
+/**
+ * This object represents an incoming inline query.
+ * @ingroup types
+ */
+class InlineQuery {
+public:
+    typedef std::shared_ptr<InlineQuery> Ptr;
+
+    /**
+     * Unique query identifier.
+     */
+    std::string id;
+
+    /**
+     * Sender.
+     */
+    User::Ptr from;
+
+    /**
+     * Text of the query.
+     */
+    std::string query;
+
+    /**
+     * Offset of the results to be returned.
+     */
+    std::string offset;
+};
+
+}
+
+#endif //TGBOT_INLINEQUERY_H

--- a/include/tgbot/types/InlineQueryResult.h
+++ b/include/tgbot/types/InlineQueryResult.h
@@ -1,0 +1,62 @@
+//
+// Created by Andrea Giove on 26/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULT_H
+#define TGBOT_INLINEQUERYRESULT_H
+
+#include <memory>
+#include <string>
+
+namespace TgBot {
+
+/**
+ * This abstract class is base of all inline query results.
+ * @ingroup types
+ */
+class InlineQueryResult {
+public:
+    typedef std::shared_ptr<InlineQueryResult> Ptr;
+
+    virtual ~InlineQueryResult() { }
+
+    /**
+     * Type of the result.
+     */
+    std::string type;
+
+    /**
+     * Unique identifier for this result. (1-64 bytes)
+     */
+    std::string id;
+
+    /**
+     * Optional. Title of the result.
+     */
+    std::string title;
+
+    /**
+     * Text of the message t be sent. (1-4096 characters)
+     */
+    std::string messageText;
+
+    /**
+     * Optional. Send Markdown or HTML, if you want Telegram apps to
+     * show bold, italic, fixed-width text or inline URLs in your bot's message.
+     */
+    std::string parseMode;
+
+    /**
+     * Optional. Disables link previews for links in the send message.
+     */
+    bool disableWebPagePreview;
+
+    /**
+     * Optional. Url of the thumbnail for the result.
+     */
+    std::string thumbUrl;
+
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULT_H

--- a/include/tgbot/types/InlineQueryResultArticle.h
+++ b/include/tgbot/types/InlineQueryResultArticle.h
@@ -1,0 +1,54 @@
+//
+// Created by Andrea Giove on 26/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULTARTICLE_H
+#define TGBOT_INLINEQUERYRESULTARTICLE_H
+
+#include <string>
+#include <memory>
+
+#include "tgbot/types/InlineQueryResult.h"
+
+namespace TgBot {
+
+/**
+ * Represents a link to an article of web page.
+ * @ingroup types
+ */
+class InlineQueryResultArticle : public InlineQueryResult {
+public:
+    static const std::string TYPE = "article";
+
+    typedef std::shared_ptr<InlineQueryResultArticle> Ptr;
+
+    InlineQueryResultArticle() : type(TYPE) {};
+
+    /**
+     * Optional. URL of the result.
+     */
+    std::string url;
+
+    /**
+     * Optional. Pass True if you don't want the URL to be shown in the message.
+     */
+    bool hideUrl;
+
+    /**
+     * Optional. Short description of the result.
+     */
+    std::string description;
+
+    /**
+     * Optional. Thumbnail width.
+     */
+    int32_t thumbWidth;
+
+    /**
+     * Optinal. Thumbnail height
+     */
+    int32_t thumbHeight;
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULTARTICLE_H

--- a/include/tgbot/types/InlineQueryResultGif.h
+++ b/include/tgbot/types/InlineQueryResultGif.h
@@ -1,0 +1,50 @@
+//
+// Created by Andrea Giove on 27/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULTGIF_H
+#define TGBOT_INLINEQUERYRESULTGIF_H
+
+#include <string>
+#include <memory>
+
+#include "tgbot/types/InlineQueryResult.h"
+
+namespace TgBot {
+
+/**
+ * Represents a link to an animated GIF file.
+ * @ingroup types
+ */
+class InlineQueryResultGif : public InlineQueryResult {
+public:
+    static const std::string TYPE = "gif";
+
+    typedef std::shared_ptr<InlineQueryResultGif> Ptr;
+
+    InlineQueryResultGif() : type(TYPE) {};
+
+    /**
+     * A valid URL for the GIF file.
+     */
+    std::string gifUrl;
+
+    /**
+     * Optional. Width of the GIF.
+     */
+    int32_t gifWidth;
+
+    /**
+     * Optional. Height of the GIF.
+     */
+    int32_t gifHeight;
+
+    /**
+     * Optional. Caption for the GIF file to be sent.
+     */
+    std::string caption;
+
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULTGIF_H

--- a/include/tgbot/types/InlineQueryResultMpeg4Gif.h
+++ b/include/tgbot/types/InlineQueryResultMpeg4Gif.h
@@ -1,0 +1,46 @@
+//
+// Created by Andrea Giove on 27/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULTMPEG4GIF_H
+#define TGBOT_INLINEQUERYRESULTMPEG4GIF_H
+
+namespace TgBot {
+
+/**
+ * Represents a link to a video animation (H.264/MPEG-4 AVC video without sound).
+ * @ingroup types
+ */
+class InlineQueryResultMpeg4Gif : public InlineQueryResult {
+public:
+	static const std::string TYPE = "mpeg4_gif";
+
+	typedef std::shared_ptr<InlineQueryResultMpeg4Gif> Ptr;
+
+	InlineQueryResultMpeg4Gif() : type(TYPE) {};
+
+	/**
+	 * A valid URL for the MP4 file.
+	 */
+	std::string mpeg4Url;
+
+	/**
+	 * Optional. Video width.
+	 */
+	int32_t mpeg4Width;
+
+	/**
+	 * Optional. Video height.
+	 */
+	int32_t mpeg4Height;
+
+	/**
+	 * Optional. Caption of the MPEG-4 file to be sent.
+	 */
+	std::string caption;
+
+
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULTMPEG4GIF_H

--- a/include/tgbot/types/InlineQueryResultPhoto.h
+++ b/include/tgbot/types/InlineQueryResultPhoto.h
@@ -1,0 +1,54 @@
+//
+// Created by Andrea Giove on 26/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULTPHOTO_H
+#define TGBOT_INLINEQUERYRESULTPHOTO_H
+
+#include <string>
+#include <memory>
+
+#include "tgbot/types/InlineQueryResult.h"
+
+namespace TgBot {
+
+/**
+ * Represents a link to a photo.
+ * @ingroup types
+ */
+class InlineQueryResultPhoto : public InlineQueryResult {
+public:
+    static const std::string TYPE = "photo";
+
+    typedef std::shared_ptr<InlineQueryResultPhoto> Ptr;
+
+    InlineQueryResultPhoto() : type(TYPE) {};
+
+    /**
+     * A valid URL of the photo.
+     */
+    std::string photoUrl;
+
+    /**
+     * Optional. Width of the photo.
+     */
+    int32_t photoWidth;
+
+    /**
+     * Optional. Height of the photo.
+     */
+    int32_t photoHeight;
+
+    /**
+     * Optional. Short description of the result.
+     */
+    std::string description;
+
+    /**
+     * Optional. Caption of the photo to be sent.
+     */
+    std::string caption;
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULTPHOTO_H

--- a/include/tgbot/types/InlineQueryResultVideo.h
+++ b/include/tgbot/types/InlineQueryResultVideo.h
@@ -1,0 +1,55 @@
+//
+// Created by Andrea Giove on 27/03/16.
+//
+
+#ifndef TGBOT_INLINEQUERYRESULTVIDEO_H
+#define TGBOT_INLINEQUERYRESULTVIDEO_H
+
+namespace TgBot {
+
+/**
+ * Represents link to a page containing an embedded video player or a video file.
+ * @ingroup types
+ */
+class InlineQueryResultVideo : public InlineQueryResult {
+public:
+	static const std::string TYPE = "video";
+
+	typedef std::shared_ptr<InlineQueryResultVideo> Ptr;
+
+	InlineQueryResultVideo() : type(TYPE) {};
+
+	/**
+	 * A valid URL for the embedded video player or video file.
+	 */
+	std::string videoUrl;
+
+	/**
+	 * Mime type of the content of video url, "text/html" or "video/mp4".
+	 */
+	std::string mimeType;
+
+	/**
+	 * Optional. Video width.
+	 */
+	int32_t videoWidth;
+
+	/**
+	 * Optional. Video height.
+	 */
+	int32_t videoHeight;
+
+	/**
+	 * Optional. Video duration.
+	 */
+	int32_t videoDuration;
+
+	/**
+	 * Optional. Short description of the result.
+	 */
+	std::string description;
+
+};
+}
+
+#endif //TGBOT_INLINEQUERYRESULTVIDEO_H

--- a/include/tgbot/types/Message.h
+++ b/include/tgbot/types/Message.h
@@ -114,6 +114,8 @@ public:
 	 */
 	Video::Ptr video;
 
+	// TODO voice
+
 	/**
 	 * Optional. Message is a shared contact, information about the contact.
 	 */
@@ -158,6 +160,27 @@ public:
 	 * Optional. Text description of the photo or the video.
 	 */
 	std::string caption;
+
+	/**
+	 * Optional. Service message: the supergroup has been created.
+	 */
+	bool supergroupChatCreated;
+
+	/**
+	 * Optional. Service message: the channel has been created.
+	 */
+	bool channelChatCreated;
+
+	/**
+	 * Optional. The group has been migrated to a supergroup with the specified identifier, not exceeding 1e13 by absolute value.
+	 */
+	int64_t migrateToChatId;
+
+	/**
+	 * Optional. The supergroup has been migrated from a group with the specified identifier, not exceeding 1e13 by absolute value
+	 */
+	int64_t migrateFromChatId;
+
 };
 
 }

--- a/include/tgbot/types/Update.h
+++ b/include/tgbot/types/Update.h
@@ -26,6 +26,8 @@
 #include <memory>
 
 #include "tgbot/types/Message.h"
+#include "tgbot/types/InlineQuery.h"
+#include "tgbot/types/ChosenInlineResult.h"
 
 namespace TgBot {
 
@@ -47,6 +49,16 @@ public:
 	 * Optional. New incoming message of any kind — text, photo, sticker, etc.
 	 */
 	Message::Ptr message;
+
+	/**
+	 * Optional. New incoming inline query
+	 */
+	InlineQuery::Ptr inlineQuery;
+
+	/**
+	 * Optional. The result of an inline query that was chosen by a user and sent to their chat partner.
+	 */
+	ChosenInlineResult::Ptr chosenInlineResult;
 };
 
 }

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -255,6 +255,17 @@ void Api::setWebhook(const string& url) const {
 	sendRequest("setWebhook", args);
 }
 
+void Api::answerInlineQuery(const std::string inlineQueryId, const std::vector<InlineQueryResult::Ptr> results,
+                            int32_t cacheTime=300, bool isPersonal=false, const std::string& nextOffset=""){
+	vector<HttpReqArg> args;
+	args.push_back(HttpReqArg("inline_query_id", inlineQueryId));
+	args.push_back(HttpReqArg("results", results, TgTypeParser::getInstance().parseInlineQueryResult));
+	args.push_back(HttpReqArg("cache_time", cacheTime));
+	args.push_back(HttpReqArg("is_personal", isPersonal));
+	args.push_back(HttpReqArg("next_offset", nextOffset));
+	sendRequest("answerInlineQuery", args);
+}
+
 ptree Api::sendRequest(const string& method, const vector<HttpReqArg>& args) const {
 
 	string url = "https://api.telegram.org/bot";

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -348,6 +348,8 @@ Update::Ptr TgTypeParser::parseJsonAndGetUpdate(const ptree& data) const {
 	Update::Ptr result(new Update);
 	result->updateId = data.get<int32_t>("update_id");
 	result->message = parseJsonAndGetMessage(data.find("message")->second);
+	result->inlineQuery = parseJsonAndGetInlineQuery(data.find("inline_query")->second);
+	result->chosenInlineResult = parseJsonAndGetChosenInlineResult(data.find("chosen_inline_result")->second);
 	return result;
 }
 
@@ -359,6 +361,8 @@ string TgTypeParser::parseUpdate(const Update::Ptr& object) const {
 	result += '{';
 	appendToJson(result, "update_id", object->updateId);
 	appendToJson(result, "message", parseMessage(object->message));
+	appendToJson(result, "inline_query", parseInlineQuery(object->inlineQuery));
+	appendToJson(result, "chosen_inline_result", parseChosenInlineResult(object->chosenInlineResult))
 	result.erase(result.length() - 1);
 	result += '}';
 	return result;
@@ -485,6 +489,246 @@ std::string TgTypeParser::parseGenericReply(const GenericReply::Ptr& object) con
 	} else {
 		return parseReplyKeyboardMarkup(static_pointer_cast<ReplyKeyboardMarkup>(object));
 	}
+}
+
+InlineQuery::Ptr TgTypeParser::parseJsonAndGetInlineQuery(const boost::property_tree::ptree& data) const {
+	InlineQuery::Ptr result(new InlineQuery);
+	result->id = data.get<string>("id");
+	result->from = tryParseJson<User>(&TgTypeParser::parseJsonAndGetUser, data, "from");
+	result->query = data.get<string>("query");
+	result->offset = data.get<string>("offset");
+
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQuery(const InlineQuery::Ptr& object) const{
+	if (!object) {
+		return "";
+	}
+	string result;
+	result += '{';
+	appendToJson(result, "id", object->id);
+	appendToJson(result, "from", parseUser(object->from));
+	appendToJson(result, "query", object->query);
+	appendToJson(result, "offset", object->offset);
+	result.erase(result.length() - 1);
+	result += '}';
+	return result;
+}
+
+InlineQueryResult::Ptr TgTypeParser::parseJsonAndGetInlineQueryResult(const boost::property_tree::ptree& data) const {
+	string type = data.get<string>("type");
+	InlineQueryResult::Ptr result;
+
+	if (type == InlineQueryResultArticle::TYPE) {
+		result = static_pointer_cast<InlineQueryResult>(parseJsonAndGetInlineQueryResultArticle(data));
+	} else if (type == InlineQueryResultPhoto::TYPE) {
+		result = static_pointer_cast<InlineQueryResult>(parseJsonAndGetInlineQueryResultPhoto(data));
+	} else if (type == InlineQueryResultGif::TYPE) {
+		result = static_pointer_cast<InlineQueryResult>(parseJsonAndGetInlineQueryResultGif(data));
+	} else if (type == InlineQueryResultMpeg4Gif::TYPE) {
+		result = static_pointer_cast<InlineQueryResult>(parseJsonAndGetInlineQueryResultMpeg4Gif(data));
+	} else if (type == InlineQueryResultVideo::TYPE) {
+		result = static_pointer_cast<InlineQueryResult>(parseJsonAndGetInlineQueryResultVideo(data));
+	} else {
+		result = make_shared<InlineQueryResult>();
+	}
+
+	result->id = data.get<string>("id");
+	result->title = data.get<string>("title", "");
+	result->messageText = data.get<string>("message_text", "");
+	result->parseMode = data.get<string>("parse_mode", "");
+	result->disableWebPagePreview = data.get("disable_web_page_preview", false);
+	result->thumbUrl = data.get<string>("thumb_url", "");
+
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQueryResult(const InlineQueryResult::Ptr& object) const {
+	if (!object){
+		return "";
+	}
+
+	string result;
+	result += '{';
+	appendToJson(result, "id", object->id);
+	appendToJson(result, "type", object->type);
+	appendToJson(result, "title", object->title);
+	appendToJson(result, "message_text", object->messageText);
+	appendToJson(result, "parse_mode", object->parseMode);
+	appendToJson(result, "disable_web_page_preview", object->disableWebPagePreview);
+	appendToJson(result, "thumb_url", object->thumbUrl);
+
+	if (object->type == InlineQueryResultArticle::TYPE){
+		result += parseInlineQueryResultArticle(static_pointer_cast<InlineQueryResultArticle>(object));
+	} else if (object->type == InlineQueryResultPhoto::TYPE){
+		result += parseInlineQueryResultPhoto(static_pointer_cast<InlineQueryResultPhoto>(object));
+	} else if (object->type == InlineQueryResultGif::TYPE){
+		result += parseInlineQueryResultGif(static_pointer_cast<InlineQueryResultGif>(object));
+	} else if (object->type == InlineQueryResultMpeg4Gif::TYPE){
+		result += parseInlineQueryResultMpeg4Gif(static_pointer_cast<InlineQueryResultMpeg4Gif>(object));
+	} else if (object->type == InlineQueryResultVideo::TYPE){
+		result += parseInlineQueryResultVideo(static_pointer_cast<InlineQueryResultVideo>(object));
+	}
+
+	result.erase(result.length() - 1);
+	result += '}';
+	return result;
+}
+
+InlineQueryResultArticle::Ptr TgTypeParser::parseJsonAndGetInlineQueryResultArticle(const boost::property_tree::ptree& data) const {
+	// NOTE: This function will be called by parseJsonAndGgetInlineQueryResult().
+	InlineQueryResultArticle::Ptr result(new InlineQueryResultArticle);
+	result->url = data.get<string>("url", "");
+	result->hideUrl = data.get("hide_url", false);
+	result->description = data.get<string>("description", "");
+	result->thumbWidth = data.get("thumb_width", 0);
+	result->thumbHeight = data.get("thumb_height", 0);
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQueryResultArticle(const InlineQueryResultArticle::Ptr& object) const {
+	if (!object){
+		return " ";
+	}
+	// This function will be called by parseInlineQueryResult(), so I don't add
+	// curly brackets to the result string.
+	string result;
+	appendToJson(result, "url", object->url);
+	appendToJson(result, "hide_url", object->hideUrl);
+	appendToJson(result, "description", object->description);
+	appendToJson(result, "thumb_width", object->thumbWidth);
+	appendToJson(result, "thumb_height", object->thumbHeight);
+	// The last comma will be erased by parseInlineQueryResult().
+	return result;
+}
+
+InlineQueryResultPhoto::Ptr TgTypeParser::parseJsonAndGetInlineQueryResultPhoto(const boost::property_tree::ptree& data) const {
+	// NOTE: This function will be called by parseJsonAndGgetInlineQueryResult().
+	InlineQueryResultPhoto::Ptr result(new InlineQueryResultPhoto);
+	result->photoUrl = data.get<string>("photo_url", "");
+	result->photoWidth = data.get("photo_width", 0);
+	result->photoHeight = data.get("photo_height", 0);
+	result->description = data.get<string>("description", "");
+	result->caption = data.get<string>("caption", "");
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQueryResultPhoto(const InlineQueryResultPhoto::Ptr& object) const{
+	if (!object){
+		return " ";
+	}
+	// This function will be called by parseInlineQueryResult(), so I don't add
+	// curly brackets to the result string.
+	string result;
+	appendToJson(result, "photo_url", object->photoUrl);
+	appendToJson(result, "photo_width", object->photoWidth);
+	appendToJson(result, "photo_height", object->photoHeight);
+	appendToJson(result, "description", object->description);
+	appendToJson(result, "caption", object->caption);
+	// The last comma will be erased by parseInlineQueryResult().
+	return result;
+}
+
+InlineQueryResultGif::Ptr TgTypeParser::parseJsonAndGetInlineQueryResultGif(const boost::property_tree::ptree& data) const {
+	// NOTE: This function will be called by parseJsonAndGgetInlineQueryResult().
+	InlineQueryResultGif::Ptr result(new InlineQueryResultGif);
+	result->gifUrl = data.get<string>("gif_url", "");
+	result->gifWidth = data.get("gif_width", 0);
+	result->gifHeight = data.get("gif_height", 0);
+	result->caption = data.get<string>("caption", "");
+	return result;
+}
+std::string TgTypeParser::parseInlineQueryResultGif(const InlineQueryResultGif::Ptr& object) const {
+	if (!object){
+		return " ";
+	}
+	// This function will be called by parseInlineQueryResult(), so I don't add
+	// curly brackets to the result string.
+	string result;
+	appendToJson(result, "gif_url", object->gifUrl);
+	appendToJson(result, "gif_width", object->gifWidth);
+	appendToJson(result, "gif_height", object->gifHeight);
+	appendToJson(result, "caption", object->caption);
+	// The last comma will be erased by parseInlineQueryResult().
+	return result;
+}
+
+InlineQueryResultMpeg4Gif::Ptr TgTypeParser::parseJsonAndGetInlineQueryResultMpeg4Gif(const boost::property_tree::ptree& data) const {
+	// NOTE: This function will be called by parseJsonAndGgetInlineQueryResult().
+	InlineQueryResultMpeg4Gif::Ptr result(new InlineQueryResultMpeg4Gif);
+	result->mpeg4Url = data.get<string>("mpeg4_url");
+	result->mpeg4Width = data.get("mpeg4_width", 0);
+	result->mpeg4Height = data.get("mpeg4_height", 0);
+	result->caption = data.get("caption", "");
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQueryResultMpeg4Gif(const InlineQueryResultMpeg4Gif::Ptr& object) const {
+	if (!object){
+		return " ";
+	}
+	// This function will be called by parseInlineQueryResult(), so I don't add
+	// curly brackets to the result string.
+	string result;
+	appendToJson(result, "mpeg4_url", object->mpeg4Url);
+	appendToJson(result, "mpeg4_width", object->mpeg4Width);
+	appendToJson(result, "mpeg4_height", object->mpeg4Height);
+	appendToJson(result, "caption", object->caption);
+	// The last comma will be erased by parseInlineQueryResult().
+	return result;
+}
+
+InlineQueryResultVideo::Ptr TgTypeParser::parseJsonAndGetInlineQueryResultVideo(const boost::property_tree::ptree& data) const {
+	// NOTE: This function will be called by parseJsonAndGgetInlineQueryResult().
+	InlineQueryResultVideo::Ptr result(new InlineQueryResultVideo);
+	result->videoUrl = data.get<string>("video_url");
+	result->mimeType = data.get<string>("mime_type");
+	result->videoWidth = data.get("video_height", 0);
+	result->videoHeight = data.get("video_height", 0);
+	result->videoDuration = data.get("video_duration", 0);
+	result->description = data.get<string>("description", "");
+	return result;
+}
+
+std::string TgTypeParser::parseInlineQueryResultVideo(const InlineQueryResultVideo::Ptr& object) const {
+	if (!object){
+		return " ";
+	}
+	// This function will be called by parseInlineQueryResult(), so I don't add
+	// curly brackets to the result string.
+	string result;
+	appendToJson(result, "video_url", object->videoUrl);
+	appendToJson(result, "mime_type", object->mimeType);
+	appendToJson(result, "video_width", object->videoWidth);
+	appendToJson(result, "video_height", object->videoHeight);
+	appendToJson(result, "video_duration", object->videoDuration);
+	appendToJson(result, "description", object->description);
+	// The last comma will be erased by parseInlineQueryResult().
+	return result;
+}
+
+ChosenInlineResult::Ptr TgTypeParser::parseJsonAndGetChosenInlineResult(const boost::property_tree::ptree& data) const {
+	ChosenInlineResult::Ptr result(new ChosenInlineResult);
+	result->resultId = data.get<string>("result_id");
+	result->user = tryParseJson<User>(&TgTypeParser::parseJsonAndGetUser, data, "user");
+	result->query = data.get<string>("query");
+	return result;
+}
+
+std::string TgTypeParser::parseChosenInlineResult(const ChosenInlineResult::Ptr& object) const {
+	if (!object){
+		return "";
+	}
+
+	string result;
+	result += '{';
+	appendToJson(result, "result_id", object->resultId);
+	appendToJson(result, "user", parseUser(object->user));
+	appendToJson(result, "query", object->query);
+	result.erase(result.length() - 1);
+	result += '}';
+	return result;
 }
 
 void TgTypeParser::appendToJson(string& json, const string& varName, const string& value) const {

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -126,6 +126,10 @@ Message::Ptr TgTypeParser::parseJsonAndGetMessage(const ptree& data) const {
 	result->deleteChatPhoto = data.get("delete_chat_photo", false);
 	result->groupChatCreated = data.get("group_chat_created", false);
 	result->caption = data.get("caption", false);
+	result->supergroupChatCreated = data.get("supergroup_chat_created", false);
+	result->channelChatCreated = data.get("channel_chat_created", false);
+	result->migrateToChatId = data.get<int64_t>("migrate_to_chat_id", 0);
+	result->migrateFromChatId = data.get<int64_t>("migrate_from_chat_id", 0);
 	return result;
 }
 
@@ -157,6 +161,10 @@ string TgTypeParser::parseMessage(const Message::Ptr& object) const {
 	appendToJson(result, "delete_chat_photo", object->deleteChatPhoto);
 	appendToJson(result, "group_chat_created", object->groupChatCreated);
 	appendToJson(result, "caption", object->caption);
+	appendToJson(result, "supergroup_chat_created", object->supergroupChatCreated);
+	appendToJson(result, "channel_chat_created", object->channelChatCreated);
+	appendToJson(result, "migrate_to_chat_id", object->migrateToChatId);
+	appendToJson(result, "migrate_from_chat_id", object->migrateFromChatId);
 	result.erase(result.length() - 1);
 	result += '}';
 	return result;


### PR DESCRIPTION
I've tried to extend the api adding the support the **new inline** mode introduced by Telegram in January 2016. I added the new types (_InlineQuery, InlineQueryResultArticle, InlineQueryResultPhoto, InlineQueryResultGif, InlineQueryResultMpeg4Gif _and_ InlineQueryResultVideo_) and the new method (_answerInlineQuery_).
The **Upload class** has been edited according to the Telegram documentation.
I took the liberty to add two **new events** in the broadcast handler: _onInlineQuery_ and _onChosenInlineResult_. To do so, I also edited the event handler class.

In this days I would try to add some **automatic tests** to be sure that the parsing works fine.

I hope I was helpful.

PS: Do you use Clion as IDE? If so, I will really appreciate if you could pass me your configuration files in order to have the same development environment.