### PR TITLE
StringTools: small fix for perfomance

### DIFF
--- a/src/tools/StringTools.cpp
+++ b/src/tools/StringTools.cpp
@@ -84,7 +84,7 @@ string generateRandomString(size_t length) {
 	return result;
 }
 
-string urlEncode(const string& value, const std::string additionalLegitChars) {
+string urlEncode(const string& value, const std::string& additionalLegitChars) {
 	static const string legitPunctuation = "-_.~";
 	ostringstream result;
 	result.fill('0');


### PR DESCRIPTION
Function parameter 'additionalLegitChars' should be passed by reference.