### PR TITLE
ReplyKeyboardMarkup and UTF-8

### DIFF
--- a/include/tgbot/types/KeyboardButton.h
+++ b/include/tgbot/types/KeyboardButton.h
@@ -31,12 +31,12 @@ public:
      * Optional. If True, the user's phone number will be sent as a contact
 	 * when the button is pressed. Available in private chats only
      */
-	bool requestContact;
+	bool requestContact = false;
 
     /**
      * Optional. If True, the user's current location will be sent when the button is pressed. Available in private chats only. 
      */
-	bool requestLocation;
+	bool requestLocation = false;
 };
 
 }

--- a/include/tgbot/types/ReplyKeyboardMarkup.h
+++ b/include/tgbot/types/ReplyKeyboardMarkup.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include "tgbot/types/GenericReply.h"
+#include "tgbot/types/KeyboardButton.h"
 
 namespace TgBot {
 
@@ -41,25 +42,25 @@ public:
 	typedef std::shared_ptr<ReplyKeyboardMarkup> Ptr;
 
 	/**
-	 * Array of button rows, each represented by an Array of Strings.
+	 * Array of button rows, each represented by an Array of KeyboardButton.
 	 */
-	std::vector<std::vector<std::string>> keyboard;
+	std::vector<std::vector<KeyboardButton::Ptr>> keyboard;
 
 	/**
 	 * Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to false, in which case the custom keyboard is always of the same height as the app's standard keyboard.
 	 */
-	bool resizeKeyboard;
+	bool resizeKeyboard = false;
 
 	/**
 	 * Optional. Requests clients to hide the keyboard as soon as it's been used. Defaults to false.
 	 */
-	bool oneTimeKeyboard;
+	bool oneTimeKeyboard = false;
 
 	/**
 	 * Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
 	 * Example: A user requests to change the bot‘s language, bot replies to the request with a keyboard to select the new language. Other users in the group don’t see the keyboard.
 	 */
-	bool selective;
+	bool selective = false;
 };
 
 }

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -467,7 +467,8 @@ std::string TgTypeParser::parseReplyKeyboardMarkup(const ReplyKeyboardMarkup::Pt
 		result.erase(result.length() - 1);
 		result += "],";
 	}
-	result.erase(result.length() - 1);
+	if (!object->keyboard.empty())
+		result.erase(result.length() - 1);
 	result += "],";
 	appendToJson(result, "resize_keyboard", object->resizeKeyboard);
 	appendToJson(result, "one_time_keyboard", object->oneTimeKeyboard);
@@ -1329,7 +1330,8 @@ std::string TgTypeParser::parseInlineKeyboardMarkup(const InlineKeyboardMarkup::
 		result.erase(result.length() - 1);
 		result += "],";
 	}
-	result.erase(result.length() - 1);
+	if (!object->inlineKeyboard.empty())
+		result.erase(result.length() - 1);
 	result += "]}";
 	return result;
 }

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -442,16 +442,12 @@ string TgTypeParser::parseFile(const File::Ptr& object) const {
 
 ReplyKeyboardMarkup::Ptr TgTypeParser::parseJsonAndGetReplyKeyboardMarkup(const boost::property_tree::ptree& data) const {
 	ReplyKeyboardMarkup::Ptr result(new ReplyKeyboardMarkup);
-	for (const pair<const string, ptree>& item : data.find("keyboard")->second) {
-		vector<string> array;
-		for (const pair<const string, ptree>& innerItem : item.second) {
-			array.push_back(innerItem.second.data());
-		}
-		result->keyboard.push_back(array);
+	for (const boost::property_tree::ptree::value_type& item : data.find("keyboard")->second){
+		result->keyboard.push_back(parseJsonAndGetArray<KeyboardButton>(&TgTypeParser::parseJsonAndGetKeyboardButton, item.second));
 	}
-	result->resizeKeyboard = data.get<bool>("resize_keyboard");
-	result->oneTimeKeyboard = data.get<bool>("one_time_keyboard");
-	result->selective = data.get<bool>("selective");
+	result->resizeKeyboard = data.get<bool>("resize_keyboard", false);
+	result->oneTimeKeyboard = data.get<bool>("one_time_keyboard", false);
+	result->selective = data.get<bool>("selective", false);
 	return result;
 }
 
@@ -462,12 +458,11 @@ std::string TgTypeParser::parseReplyKeyboardMarkup(const ReplyKeyboardMarkup::Pt
 	string result;
 	result += '{';
 	result += "\"keyboard\":[";
-	for (vector<string>& item : object->keyboard) {
+	for (vector<KeyboardButton::Ptr>& item : object->keyboard) {
 		result += '[';
-		for (string& innerItem : item) {
-			result += '"';
-			result += innerItem;
-			result += "\",";
+		for (KeyboardButton::Ptr& innerItem : item) {
+			result += parseKeyboardButton(innerItem);
+			result += ',';
 		}
 		result.erase(result.length() - 1);
 		result += "],";

--- a/src/tools/StringTools.cpp
+++ b/src/tools/StringTools.cpp
@@ -84,20 +84,22 @@ string generateRandomString(size_t length) {
 	return result;
 }
 
+
 string urlEncode(const string& value, const std::string& additionalLegitChars) {
-	static const string legitPunctuation = "-_.~";
-	ostringstream result;
-	result.fill('0');
-	result << hex;
-	for (const char& c : value) {
-		if (isalnum(c) || legitPunctuation.find(c) != legitPunctuation.npos || additionalLegitChars.find(c) != additionalLegitChars.npos) {
-			result << c;
+	static const string legitPunctuation = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~:";
+	std::stringstream ss;
+	std::string t;
+	for (auto const &c : value) {
+		if ((legitPunctuation.find(c) == std::string::npos)
+			&& (additionalLegitChars.find(c)==std::string::npos)) {
+			ss << '%' << std::uppercase << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)(unsigned char)c;
+			t = ss.str();
 		} else {
-			result << '%' << setw(2) << int((unsigned char) c);
+			ss << c;
 		}
 	}
 
-	return result.str();
+	return ss.str();
 }
 
 string urlDecode(const string& value) {

--- a/test/tgbot/tools/StringTools.cpp
+++ b/test/tgbot/tools/StringTools.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(split) {
 
 BOOST_AUTO_TEST_CASE(urlEncode) {
 	string t = StringTools::urlEncode("`1234567890-qwertyuiop[]\\asdfghjkl;'zxcvbnm,./~!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:ZXCVBNM<>? ");
-	string e = "%601234567890-qwertyuiop%5b%5d%5casdfghjkl%3b%27zxcvbnm%2c.%2f~%21%40%23%24%25%5e%26%2a%28%29_%2bQWERTYUIOP%7b%7d%7cASDFGHJKL%3aZXCVBNM%3c%3e%3f%20";
+	string e = "%601234567890-qwertyuiop%5B%5D%5Casdfghjkl%3B%27zxcvbnm%2C.%2F~%21%40%23%24%25%5E%26%2A%28%29_%2BQWERTYUIOP%7B%7D%7CASDFGHJKL:ZXCVBNM%3C%3E%3F%20";
 	BOOST_CHECK_MESSAGE(t == e, diffS(t, e));
 }
 


### PR DESCRIPTION
Hi! I have new changes.
1) fix function ReplyKeyboardMarkup
2) fix function encodeUrl. The previous version caused the error in process of using UTF-8. 
 It's now possible to use UTF-8. 

bot.getApi().sendMessage(message->chat->id, "Пример кириллицы");
bot.getApi().sendMessage(message->chat->id, "\xF0\x9F\x91\x8D"); // emoji