### PR TITLE
Specified minimum version of Boost.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,9 @@ include_directories(${OPENSSL_INCLUDE_DIR})
 # boost
 set(Boost_USE_MULTITHREADED ON)
 if (ENABLE_TESTS)
-	find_package(Boost COMPONENTS system iostreams unit_test_framework REQUIRED)
+	find_package(Boost 1.59.0 COMPONENTS system iostreams unit_test_framework REQUIRED)
 else()
-	find_package(Boost COMPONENTS system iostreams REQUIRED)
+	find_package(Boost 1.59.0 COMPONENTS system iostreams REQUIRED)
 endif()
 include_directories(${Boost_INCLUDE_DIR})
 

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -332,7 +332,7 @@ Message::Ptr Api::sendVoice(int64_t chatId, const std::string& voiceId, const st
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
-	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendVideo", args));
+	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendVoice", args));
 }
 
 Message::Ptr Api::sendLocation(int64_t chatId, float latitude, float longitude, int32_t replyToMessageId, const GenericReply::Ptr& replyMarkup, bool disableNotification) const {


### PR DESCRIPTION
Hello!  I suggest to set the minimum version of Boost, because boost::property_tree::read_json don't work with cyrillic correctly in Boost lower 1.59 (do not read it at all).  
Thank you!
![image_120](https://cloud.githubusercontent.com/assets/10834470/21973483/6bea6e42-dbda-11e6-8e51-81a56a58de0b.png)
![image_122](https://cloud.githubusercontent.com/assets/10834470/21974005/a5dd521a-dbdd-11e6-8ff7-c18ac7d64c56.png)
