### PR TITLE
remove hard-code parameters in TgLongPoll() for getUpdates()

### DIFF
--- a/include/tgbot/net/TgLongPoll.h
+++ b/include/tgbot/net/TgLongPoll.h
@@ -36,8 +36,8 @@ namespace TgBot {
 class TgLongPoll {
 
 public:
-	TgLongPoll(const Api* api, const EventHandler* eventHandler);
-	TgLongPoll(const Bot& bot);
+	TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t, int32_t, const std::shared_ptr<std::vector<std::string>>&);
+	TgLongPoll(const Bot& bot, int32_t = 100, int32_t = 60, const std::shared_ptr<std::vector<std::string>>& = nullptr);
 
 	/**
 	 * Starts long poll. After new update will come, this method will parse it and send to EventHandler which invokes your listeners. Designed to be executed in a loop.
@@ -46,6 +46,9 @@ public:
 
 private:
 	int32_t _lastUpdateId = 0;
+	int32_t _limit;
+	int32_t _timeout;
+	std::shared_ptr<std::vector<std::string>> _stringarrayptr;
 	const Api* _api;
 	const EventHandler* _eventHandler;
 };

--- a/include/tgbot/net/TgLongPoll.h
+++ b/include/tgbot/net/TgLongPoll.h
@@ -48,7 +48,7 @@ private:
 	int32_t _lastUpdateId = 0;
 	int32_t _limit;
 	int32_t _timeout;
-	std::shared_ptr<std::vector<std::string>> _stringarrayptr;
+	std::shared_ptr<std::vector<std::string>> _allowupdates;
 	const Api* _api;
 	const EventHandler* _eventHandler;
 };

--- a/src/net/TgLongPoll.cpp
+++ b/src/net/TgLongPoll.cpp
@@ -24,14 +24,16 @@
 
 namespace TgBot {
 
-TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler) : _api(api), _eventHandler(eventHandler) {
+TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& stringarrayptr) 
+	: _api(api), _eventHandler(eventHandler), _limit(limit), _timeout(timeout), _stringarrayptr(stringarrayptr) {
 }
 
-TgLongPoll::TgLongPoll(const Bot& bot) : TgLongPoll(&bot.getApi(), &bot.getEventHandler()) {
+TgLongPoll::TgLongPoll(const Bot& bot, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& stringarrayptr) :
+	TgLongPoll(&bot.getApi(), &bot.getEventHandler(), limit, timeout, stringarrayptr) {
 }
 
 void TgLongPoll::start() {
-	std::vector<Update::Ptr> updates = _api->getUpdates(_lastUpdateId, 100, 60);
+	std::vector<Update::Ptr> updates = _api->getUpdates(_lastUpdateId, _limit, _timeout, _stringarrayptr);
 	for (Update::Ptr& item : updates) {
 		if (item->updateId >= _lastUpdateId) {
 			_lastUpdateId = item->updateId + 1;

--- a/src/net/TgLongPoll.cpp
+++ b/src/net/TgLongPoll.cpp
@@ -24,16 +24,16 @@
 
 namespace TgBot {
 
-TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& stringarrayptr) 
-	: _api(api), _eventHandler(eventHandler), _limit(limit), _timeout(timeout), _stringarrayptr(stringarrayptr) {
+TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates)
+	: _api(api), _eventHandler(eventHandler), _limit(limit), _timeout(timeout), _allowupdates(allowupdates) {
 }
 
-TgLongPoll::TgLongPoll(const Bot& bot, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& stringarrayptr) :
-	TgLongPoll(&bot.getApi(), &bot.getEventHandler(), limit, timeout, stringarrayptr) {
+TgLongPoll::TgLongPoll(const Bot& bot, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates) :
+	TgLongPoll(&bot.getApi(), &bot.getEventHandler(), limit, timeout, allowupdates) {
 }
 
 void TgLongPoll::start() {
-	std::vector<Update::Ptr> updates = _api->getUpdates(_lastUpdateId, _limit, _timeout, _stringarrayptr);
+	std::vector<Update::Ptr> updates = _api->getUpdates(_lastUpdateId, _limit, _timeout, _allowupdates);
 	for (Update::Ptr& item : updates) {
 		if (item->updateId >= _lastUpdateId) {
 			_lastUpdateId = item->updateId + 1;


### PR DESCRIPTION
Make TgLongPoll constructed with user-specified parameters for getUpdates() instead of hard-code

Due to the fact that TgBot::Api::StringArrayPtr is private, I use std::shared_ptr<std::vector<std::string>> instead.