### PR TITLE
fix the default value for caption

### DIFF
--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -140,7 +140,7 @@ Message::Ptr TgTypeParser::parseJsonAndGetMessage(const ptree& data) const {
 	result->newChatPhoto = parseJsonAndGetArray<PhotoSize>(&TgTypeParser::parseJsonAndGetPhotoSize, data, "new_chat_photo");
 	result->deleteChatPhoto = data.get("delete_chat_photo", false);
 	result->groupChatCreated = data.get("group_chat_created", false);
-	result->caption = data.get("caption", false);
+	result->caption = data.get("caption", "");
 	result->supergroupChatCreated = data.get("supergroup_chat_created", false);
 	result->channelChatCreated = data.get("channel_chat_created", false);
 	result->migrateToChatId = data.get<int64_t>("migrate_to_chat_id", 0);


### PR DESCRIPTION
caption is a std::string, its default value should be an empty string, not false. In fact, when using false as the default value, I get  a strange result. It seems that the boost is trying to convert false to an string with only ONE character '\0' if there is no caption in original response. This causes size() and length() return 1, empty() return false.

![e29o8 h7fs aqhug1 k sm](https://user-images.githubusercontent.com/30623163/39034726-064b7948-44aa-11e8-9f05-32a8fbd011c0.png)

After I change false to "",  everthing goes well.

My compiler is msvc, and the boost library version is  1.66.0.