### PR TITLE
Bot API 3.6 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documentation is located [here](http://reo7sp.github.io/tgbot-cpp).
 - [x] Bot API 3.3
 - [x] Bot API 3.4
 - [x] Bot API 3.5 / **_Invoice is not implemented._** 
-- [ ] Bot API 3.6
+- [x] Bot API 3.6
 
 ## Library compilation
 

--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -77,7 +77,8 @@ public:
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
-	Message::Ptr sendMessage(int64_t chatId, const std::string& text, bool disableWebPagePreview = false, int32_t replyToMessageId = 0, const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
+	Message::Ptr sendMessage(int64_t chatId, const std::string& text, bool disableWebPagePreview = false, int32_t replyToMessageId = 0,
+							 const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to forward messages of any kind.
@@ -96,11 +97,12 @@ public:
 	 * @param caption Optional. Photo caption.
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendPhoto(int64_t chatId, const InputFile::Ptr photo, const std::string& caption = "", int32_t replyToMessageId = 0,
-	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send photos.
@@ -109,11 +111,12 @@ public:
 	 * @param caption Optional. Photo caption.
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendPhoto(int64_t chatId, const std::string& photoId, const std::string& caption = "", int32_t replyToMessageId = 0,
-	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Document).
@@ -125,12 +128,13 @@ public:
 	 * @param title Track name
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendAudio(int64_t chatId, const InputFile::Ptr audio, const std::string &caption = "", int32_t duration = 0,
 	                       const std::string& performer = "", const std::string& title = "", int32_t replyToMessageId = 0,
-	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .ogg file encoded with OPUS (other formats may be sent as Document).
@@ -142,12 +146,13 @@ public:
 	 * @param title Track name
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendAudio(int64_t chatId, const std::string& audioId, const std::string &caption = "", int32_t duration = 0,
 	                       const std::string& performer = "", const std::string& title = "", int32_t replyToMessageId = 0,
-	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send general files.
@@ -156,11 +161,12 @@ public:
 	 * @param caption Document caption (may also be used when resending documents by file_id), 0-200 characters
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendDocument(int64_t chatId, const InputFile::Ptr document, const std::string &caption = "", int32_t replyToMessageId = 0,
-	                          const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                          const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send general files.
@@ -169,11 +175,12 @@ public:
 	 * @param caption Document caption (may also be used when resending documents by file_id), 0-200 characters
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendDocument(int64_t chatId, const std::string& documentId, const std::string &caption = "", int32_t replyToMessageId = 0,
-	                          const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                          const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send .webp stickers.
@@ -287,33 +294,37 @@ public:
 	 * Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
 	 * @param chatId Unique identifier for the target chat.
 	 * @param video Video to send.
-	 * @param duration Duration of sent video in seconds
-	 * @param width Video width
-	 * @param height Video height
-	 * @param caption Video caption (may also be used when resending videos by file_id), 0-200 characters
+	 * @param supportsStreaming Optional. Pass True, if the uploaded video is suitable for streaming.
+	 * @param duration Optional. Duration of sent video in seconds
+	 * @param width Optional. Video width
+	 * @param height Optional. Video height
+	 * @param caption Optional. Video caption (may also be used when resending videos by file_id), 0-200 characters
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. An object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
-	Message::Ptr sendVideo(int64_t chatId, const InputFile::Ptr video, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const std::string& caption = "",
-						   int32_t replyToMessageId = 0, const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	Message::Ptr sendVideo(int64_t chatId, const InputFile::Ptr video, bool supportsStreaming = false, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const std::string& caption = "",
+						   int32_t replyToMessageId = 0, const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document).
 	 * @param chatId Unique identifier for the target chat.
-	 * @param video Id of the video that is already on the Telegram servers.
-	 * @param duration Duration of sent video in seconds
-	 * @param width Video width
-	 * @param height Video height
-	 * @param caption Video caption (may also be used when resending videos by file_id), 0-200 characters
+	 * @param videoId Id of the video that is already on the Telegram servers.
+	 * @param supportsStreaming Optional. Pass True, if the uploaded video is suitable for streaming.
+	 * @param duration Optional. Duration of sent video in seconds
+	 * @param width Optional. Video width
+	 * @param height Optional. Video height
+	 * @param caption Optional. Video caption (may also be used when resending videos by file_id), 0-200 characters
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. A object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
-	Message::Ptr sendVideo(int64_t chatId, const std::string& videoId, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const std::string& caption = "",
-						   int32_t replyToMessageId = 0, const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	Message::Ptr sendVideo(int64_t chatId, const std::string& videoId, bool supportsStreaming = false, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const std::string& caption = "",
+						   int32_t replyToMessageId = 0, const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
      * Use this method to send video messages. On success, the sent Message is returned.
@@ -362,11 +373,12 @@ public:
 	 * @param duration Duration of send audio in seconds.
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. A object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendVoice(int64_t chatId, const InputFile::Ptr voice, const std::string& caption = "", int duration = 0, int32_t replyToMessageId = 0,
-	                      const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                      const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
@@ -376,11 +388,12 @@ public:
 	 * @param duration Duration of send audio in seconds.
 	 * @param replyToMessageId Optional. If the message is a reply, ID of the original message.
 	 * @param replyMarkup Optional. Additional interface options. A object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+	 * @param parseMode Optional. Set it to "Markdown" or "HTML" if you want Telegram apps to show bold, italic, fixed-width text or inline URLs in your bot's message.
 	 * @param disableNotification Optional. Sends the message silenty.
 	 * @return On success, the sent message is returned.
 	 */
 	Message::Ptr sendVoice(int64_t chatId, const std::string& voiceId, const std::string& caption = "", int duration = 0, int32_t replyToMessageId = 0,
-	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+	                       const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
 	/**
 	 * Use this method to send point on the map.

--- a/include/tgbot/types/Message.h
+++ b/include/tgbot/types/Message.h
@@ -245,6 +245,10 @@ public:
 	 */
 	Message::Ptr pinnedMessage;
 
+	/**
+	 * Optional. The domain name of the website on which the user has logged in.
+	 */
+	std::string connectedWebsite;
 };
 
 }

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -71,7 +71,7 @@ Message::Ptr Api::forwardMessage(int64_t chatId, int64_t fromChatId, int32_t mes
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("forwardMessage", args));
 }
 
-Message::Ptr Api::sendPhoto(int64_t chatId, const InputFile::Ptr photo, const string& caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendPhoto(int64_t chatId, const InputFile::Ptr photo, const string& caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("photo", photo->data, true, photo->mimeType, photo->fileName));
@@ -84,13 +84,16 @@ Message::Ptr Api::sendPhoto(int64_t chatId, const InputFile::Ptr photo, const st
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendPhoto", args));
 }
 
-Message::Ptr Api::sendPhoto(int64_t chatId, const string& photoId, const string& caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendPhoto(int64_t chatId, const string& photoId, const string& caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("photo", photoId));
@@ -103,13 +106,16 @@ Message::Ptr Api::sendPhoto(int64_t chatId, const string& photoId, const string&
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendPhoto", args));
 }
 
-Message::Ptr Api::sendAudio(int64_t chatId, const InputFile::Ptr audio, const string &caption, int32_t duration, const string& performer, const string& title, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendAudio(int64_t chatId, const InputFile::Ptr audio, const string &caption, int32_t duration, const string& performer, const string& title, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("audio", audio->data, true, audio->mimeType, audio->fileName));
@@ -131,13 +137,16 @@ Message::Ptr Api::sendAudio(int64_t chatId, const InputFile::Ptr audio, const st
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendAudio", args));
 }
 
-Message::Ptr Api::sendAudio(int64_t chatId, const string& audioId, const string &caption, int32_t duration, const string& performer, const string& title, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendAudio(int64_t chatId, const string& audioId, const string &caption, int32_t duration, const string& performer, const string& title, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("audio", audioId));
@@ -159,13 +168,16 @@ Message::Ptr Api::sendAudio(int64_t chatId, const string& audioId, const string 
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendAudio", args));
 }
 
-Message::Ptr Api::sendDocument(int64_t chatId, const InputFile::Ptr document, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendDocument(int64_t chatId, const InputFile::Ptr document, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("document", document->data, true, document->mimeType, document->fileName));
@@ -178,13 +190,16 @@ Message::Ptr Api::sendDocument(int64_t chatId, const InputFile::Ptr document, co
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendDocument", args));
 }
 
-Message::Ptr Api::sendDocument(int64_t chatId, const string& document, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendDocument(int64_t chatId, const string& document, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("document", document));
@@ -196,6 +211,9 @@ Message::Ptr Api::sendDocument(int64_t chatId, const string& document, const str
 	}
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
+	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
 	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
@@ -307,10 +325,13 @@ bool Api::deleteStickerPositionInSet(const string& sticker) const {
 	return sendRequest("setStickerPositionInSet", args).get<bool>("", false);
 }
 
-Message::Ptr Api::sendVideo(int64_t chatId, const InputFile::Ptr video, int32_t duration, int32_t width, int32_t height, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendVideo(int64_t chatId, const InputFile::Ptr video, bool supportsStreaming, int32_t duration, int32_t width, int32_t height, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("video", video->data, true, video->mimeType, video->fileName));
+	if (supportsStreaming) {
+		args.push_back(HttpReqArg("supports_streaming", supportsStreaming));
+	}
 	if (duration) {
 		args.push_back(HttpReqArg("duration", duration));
 	}
@@ -328,6 +349,9 @@ Message::Ptr Api::sendVideo(int64_t chatId, const InputFile::Ptr video, int32_t 
 	}
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
+	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
 	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
@@ -335,10 +359,13 @@ Message::Ptr Api::sendVideo(int64_t chatId, const InputFile::Ptr video, int32_t 
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendVideo", args));
 }
 
-Message::Ptr Api::sendVideo(int64_t chatId, const string& videoId, int32_t duration, int32_t width, int32_t height, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendVideo(int64_t chatId, const string& videoId, bool supportsStreaming, int32_t duration, int32_t width, int32_t height, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("video", videoId));
+	if (supportsStreaming) {
+		args.push_back(HttpReqArg("supports_streaming", supportsStreaming));
+	}
 	if (duration) {
 		args.push_back(HttpReqArg("duration", duration));
 	}
@@ -356,6 +383,9 @@ Message::Ptr Api::sendVideo(int64_t chatId, const string& videoId, int32_t durat
 	}
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
+	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
 	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
@@ -417,7 +447,7 @@ vector<Message::Ptr> Api::sendMediaGroup(int64_t chatId, const vector<InputMedia
 	return TgTypeParser::getInstance().parseJsonAndGetArray<Message>(&TgTypeParser::parseJsonAndGetMessage, sendRequest("sendMediaGroup", args));
 }
 
-Message::Ptr Api::sendVoice(int64_t chatId, const InputFile::Ptr voice, const string &caption, int duration, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendVoice(int64_t chatId, const InputFile::Ptr voice, const string &caption, int duration, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("voice", voice->data, true, voice->mimeType, voice->fileName));
@@ -433,13 +463,16 @@ Message::Ptr Api::sendVoice(int64_t chatId, const InputFile::Ptr voice, const st
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
 	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
+	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));
 	}
 	return TgTypeParser::getInstance().parseJsonAndGetMessage(sendRequest("sendVoice", args));
 }
 
-Message::Ptr Api::sendVoice(int64_t chatId, const string& voiceId, const string &caption, int duration, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendVoice(int64_t chatId, const string& voiceId, const string &caption, int duration, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
 	vector<HttpReqArg> args;
 	args.push_back(HttpReqArg("chat_id", chatId));
 	args.push_back(HttpReqArg("voice", voiceId));
@@ -454,6 +487,9 @@ Message::Ptr Api::sendVoice(int64_t chatId, const string& voiceId, const string 
 	}
 	if (replyMarkup) {
 		args.push_back(HttpReqArg("reply_markup", TgTypeParser::getInstance().parseGenericReply(replyMarkup)));
+	}
+	if (!parseMode.empty()) {
+		args.push_back(HttpReqArg("parse_mode", parseMode));
 	}
 	if (disableNotification){
 		args.push_back(HttpReqArg("disable_notification", disableNotification));

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -159,6 +159,8 @@ Message::Ptr TgTypeParser::parseJsonAndGetMessage(const ptree& data) const {
 	result->channelChatCreated = data.get("channel_chat_created", false);
 	result->migrateToChatId = data.get<int64_t>("migrate_to_chat_id", 0);
 	result->migrateFromChatId = data.get<int64_t>("migrate_from_chat_id", 0);
+	result->pinnedMessage = tryParseJson<Message>(&TgTypeParser::parseJsonAndGetMessage, data, "pinned_message");
+	result->connectedWebsite = data.get("connected_website", "");
 	return result;
 }
 
@@ -200,6 +202,8 @@ string TgTypeParser::parseMessage(const Message::Ptr& object) const {
 	appendToJson(result, "channel_chat_created", object->channelChatCreated);
 	appendToJson(result, "migrate_to_chat_id", object->migrateToChatId);
 	appendToJson(result, "migrate_from_chat_id", object->migrateFromChatId);
+	appendToJson(result, "pinned_message", parseMessage(object->pinnedMessage));
+	appendToJson(result, "connected_website", object->connectedWebsite);
 	result.erase(result.length() - 1);
 	result += '}';
 	return result;


### PR DESCRIPTION
Bot API 3.6 Update.

- [x] ~~Supported **text formatting** in media captions. Specify the desired parse_mode (Markdown or HTML) when you provide a caption.~~ 
- [x] ~~In supergroups, if the bot receives a message that is a reply, it will also receive the message to which that message is replying – even if the original message is inaccessible due to the bot's privacy settings. (In other words, replying to any message in a supergroup with a message that mentions the bot or features a command for it acts as forwarding the original message to the bot).~~
- [x] Added the new field _**connected_website**_ to Message. The bot will receive a message with this field in a private chat when a user logs in on the bot's connected website using the Login Widget and allows sending messages from your bot.
- [x] Added the new parameter _**supports_streaming**_ to the _sendVideo_ method and a field with the same name to the _InputMediaVideo_ object.