### PR TITLE
Fix compile warning (-Wreorder)

### DIFF
--- a/include/tgbot/net/TgLongPoll.h
+++ b/include/tgbot/net/TgLongPoll.h
@@ -46,12 +46,12 @@ public:
 	void start();
 
 private:
+	const Api* _api;
+	const EventHandler* _eventHandler;
 	int32_t _lastUpdateId = 0;
 	int32_t _limit;
 	int32_t _timeout;
 	std::shared_ptr<std::vector<std::string>> _allowupdates;
-	const Api* _api;
-	const EventHandler* _eventHandler;
 };
 
 }


### PR DESCRIPTION
Fix "_warning: ‘limit' will be initialized after [-Wreorder]_"