### PR TITLE
Update CMakeLists.txt so tgbot-cpp can be used as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(LIB_LIST
 
 # building project
 add_library(${PROJECT_NAME} ${SRC_LIST})
+target_include_directories(${PROJECT_NAME} PUBLIC include)
 target_link_libraries(${PROJECT_NAME} ${LIB_LIST})
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ int main() {
 All other samples are located [here](samples).
 
 
-## Library compilation
+## Dependencies
 
 Firstly you need to install some dependencies such as Boost and build tools such as CMake. On Debian-based distibutives you can do it with these commands:
 ```sh
@@ -66,13 +66,19 @@ sudo apt-get install g++ make binutils cmake libssl-dev libboost-system-dev
 ```
 If you want to use curl-based http client `CurlHttpClient`, you also need to install `libcurl4-openssl-dev` package.
 
-To compile the library execute this commands:
+## Library installation
+
+If you want to install the library system-wide:
+
 ```sh
-cd /path/where/you/have/cloned/the/library/repository
+git clone https://github.com/reo7sp/tgbot-cpp
+cd tgbot-cpp
 cmake .
 make -j4
 sudo make install
 ```
+
+Or you can treat this repository as a submodule of your project, for example, see [echobot-submodule](samples/echobot/CMakeLists.txt)
 
 ## Specific library installation notes
 

--- a/samples/echobot-submodule/CMakeLists.txt
+++ b/samples/echobot-submodule/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8.4)
+project(echobot-submodule)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+set(Boost_USE_MULTITHREADED ON)
+
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(Boost COMPONENTS system REQUIRED)
+find_package(CURL)
+include_directories(/usr/local/include ${OPENSSL_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
+if (CURL_FOUND)
+    include_directories(${CURL_INCLUDE_DIRS})
+    add_definitions(-DHAVE_CURL)
+endif()
+
+add_subdirectory(tgbot-cpp)
+add_executable(echobot-submodule src/main.cpp)
+
+target_link_libraries(echobot-submodule TgBot ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} ${CURL_LIBRARIES})

--- a/samples/echobot-submodule/Dockerfile
+++ b/samples/echobot-submodule/Dockerfile
@@ -1,0 +1,8 @@
+FROM reo7sp/tgbot-cpp
+MAINTAINER Oleg Morozenkov <a@reo7sp.ru>
+
+WORKDIR /usr/src/echobot
+COPY . .
+RUN cmake .
+RUN make -j4
+CMD ./echobot

--- a/samples/echobot-submodule/src/main.cpp
+++ b/samples/echobot-submodule/src/main.cpp
@@ -1,0 +1,46 @@
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+
+#include <tgbot/tgbot.h>
+
+using namespace std;
+using namespace TgBot;
+
+int main() {
+    string token(getenv("TOKEN"));
+    printf("Token: %s\n", token.c_str());
+
+    Bot bot(token);
+    bot.getEvents().onCommand("start", [&bot](Message::Ptr message) {
+        bot.getApi().sendMessage(message->chat->id, "Hi!");
+    });
+    bot.getEvents().onAnyMessage([&bot](Message::Ptr message) {
+        printf("User wrote %s\n", message->text.c_str());
+        if (StringTools::startsWith(message->text, "/start")) {
+            return;
+        }
+        bot.getApi().sendMessage(message->chat->id, "Your message is: " + message->text);
+    });
+
+    signal(SIGINT, [](int s) {
+        printf("SIGINT got\n");
+        exit(0);
+    });
+
+    try {
+        printf("Bot username: %s\n", bot.getApi().getMe()->username.c_str());
+        bot.getApi().deleteWebhook();
+
+        TgLongPoll longPoll(bot);
+        while (true) {
+            printf("Long poll started\n");
+            longPoll.start();
+        }
+    } catch (exception& e) {
+        printf("error: %s\n", e.what());
+    }
+
+    return 0;
+}


### PR DESCRIPTION
So someone can use this lib by just:

```
cd /path/to/your/project
git submodule add https://github.com/reo7sp/tgbot-cpp
```
Then in CMakeLists.txt:

```
add_subdirectory(tgbot-cpp)
add_executable(echobot-submodule src/main.cpp)
target_link_libraries(echobot-submodule TgBot ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} ${CURL_LIBRARIES})
```

