### PR TITLE
Add Conan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,3 @@
-env:
-   global:
-     - CONAN_USERNAME: "reo7sp"
-     - CONAN_LOGIN_USERNAME: "jgsogo"
-     - CONAN_CHANNEL: "testing"
-     - CONAN_UPLOAD: "https://api.bintray.com/conan/jgsogo/conan-packages"
-     - CONAN_STABLE_BRANCH_PATTERN: "release/*"
-     - CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "release/*"
-     - CONAN_DOCKER_32_IMAGES: 1
-
 linux: &linux
    os: linux
    dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,94 @@
-sudo: required
+env:
+   global:
+     - CONAN_USERNAME: "reo7sp"
+     - CONAN_LOGIN_USERNAME: "jgsogo"
+     - CONAN_CHANNEL: "testing"
+     - CONAN_UPLOAD: "https://api.bintray.com/conan/jgsogo/conan-packages"
+     - CONAN_STABLE_BRANCH_PATTERN: "release/*"
+     - CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "release/*"
+     - CONAN_DOCKER_32_IMAGES: 1
 
-services:
-    - docker
+linux: &linux
+   os: linux
+   dist: xenial
+   language: python
+   python: "3.7"
+   services:
+     - docker
+osx: &osx
+   os: osx
+   language: generic
+
+stages:
+  - unittest
+  - conan-linux
+  - conan-osx
+
+jobs:
+   include:
+      - <<: *linux
+        stage: unittest
+        name: unittest
+        sudo: required
+        script:
+          - docker build -t reo7sp/tgbot-cpp -f Dockerfile .
+          - docker build -t reo7sp/tgbot-cpp-test -f Dockerfile_test .
+          - docker run --rm reo7sp/tgbot-cpp-test
+
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
+
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7 CONAN_BUILD_POLICY=missing
+
+      - <<: *osx
+        stage: conan-osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_BUILD_POLICY=missing
+      - <<: *osx
+        stage: conan-osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_BUILD_POLICY=missing
+      - <<: *osx
+        stage: conan-osx
+        osx_image: xcode9
+        env: CONAN_APPLE_CLANG_VERSIONS=9.0
+      - <<: *osx
+        stage: conan-osx
+        osx_image: xcode9.4
+        env: CONAN_APPLE_CLANG_VERSIONS=9.1
+      - <<: *osx
+        stage: conan-osx
+        osx_image: xcode10
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0
+
+install:
+  - chmod +x .travis/install.sh
+  - ./.travis/install.sh
 
 script:
-     - docker build -t reo7sp/tgbot-cpp -f Dockerfile .
-     - docker build -t reo7sp/tgbot-cpp-test -f Dockerfile_test .
-     - docker run --rm reo7sp/tgbot-cpp-test
-
+  - chmod +x .travis/run.sh
+  - ./.travis/run.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install conan_package_tools
+pip install conan
+conan user

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+python build.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,24 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(TgBot)
 
+if (${CONAN_EXPORTED})
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup()
+endif()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 # options
 option(ENABLE_TESTS "Set to ON to enable building of tests" OFF)
 option(BUILD_SHARED_LIBS "Build tgbot-cpp shared/static library." OFF)
 
 # sources
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+if(WIN32)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")  # Do not activate all warnings in VS (too much output for Appveyor)
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+endif()
+
 include_directories(include)
 set(SRC_LIST
     src/Api.cpp
@@ -27,6 +39,9 @@ set(SRC_LIST
 # libs
 ## threads
 find_package(Threads REQUIRED)
+
+# zlib
+find_package(ZLIB REQUIRED)
 
 ## openssl
 find_package(OpenSSL REQUIRED)
@@ -50,6 +65,7 @@ include_directories(${Boost_INCLUDE_DIR})
 
 set(LIB_LIST
     ${CMAKE_THREAD_LIBS_INIT}
+    ${ZLIB_LIBRARIES}
     ${OPENSSL_LIBRARIES}
     ${Boost_LIBRARIES}
     ${CURL_LIBRARIES}
@@ -59,7 +75,10 @@ set(LIB_LIST
 add_library(${PROJECT_NAME} ${SRC_LIST})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 target_link_libraries(${PROJECT_NAME} ${LIB_LIST})
-install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
 
 # tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 MAINTAINER Oleg Morozenkov <a@reo7sp.ru>
 
 RUN apt-get -qq update && \
-    apt-get -qq install -y g++ make binutils cmake libssl-dev libboost-system-dev libcurl4-openssl-dev
+    apt-get -qq install -y g++ make binutils cmake libssl-dev libboost-system-dev libcurl4-openssl-dev zlib1g-dev
 
 WORKDIR /usr/src/tgbot-cpp
 COPY include include

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -2,8 +2,10 @@ FROM ubuntu:14.04
 MAINTAINER Oleg Morozenkov <a@reo7sp.ru>
 
 RUN apt-get -qq update && \
-    apt-get -qq install -y g++ make binutils cmake libssl-dev libcurl4-openssl-dev \
-                           wget build-essential python-dev autotools-dev libicu-dev libbz2-dev
+    apt-get -qq install -y g++ make binutils cmake libssl-dev libcurl4-openssl-dev
+
+RUN apt-get -qq update && \
+    apt-get -qq install -y wget build-essential python-dev autotools-dev libicu-dev libbz2-dev zlib1g-dev
 
 WORKDIR /usr/src/boost
 RUN wget -q -O boost_1_59_0.tar.gz https://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.tar.gz/download && \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,87 @@
+build: false
+
+
+environment:
+    PYTHON: "C:\\Python37"
+
+    CONAN_USERNAME: "reo7sp"
+    CONAN_LOGIN_USERNAME: "jgsogo"
+    CONAN_CHANNEL: "testing"
+    VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
+    CONAN_UPLOAD: "https://api.bintray.com/conan/jgsogo/conan-packages"
+    CONAN_STABLE_BRANCH_PATTERN: "release/*"
+    CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "release/*"
+
+    matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MT
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_ARCHS: x86_64
+          CONAN_BUILD_TYPES: Release
+          CONAN_VISUAL_RUNTIMES: MD
+
+install:
+  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - pip.exe install conan --upgrade
+  - pip.exe install conan_package_tools
+  - conan user # It creates the conan data directory
+
+test_script:
+  - python build.py
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,7 @@ build: false
 
 environment:
     PYTHON: "C:\\Python37"
-
-    CONAN_USERNAME: "reo7sp"
-    CONAN_LOGIN_USERNAME: "jgsogo"
-    CONAN_CHANNEL: "testing"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
-    CONAN_UPLOAD: "https://api.bintray.com/conan/jgsogo/conan-packages"
-    CONAN_STABLE_BRANCH_PATTERN: "release/*"
-    CONAN_UPLOAD_ONLY_WHEN_STABLE: 1 # Will only upload when the branch matches "release/*"
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/build.py
+++ b/build.py
@@ -4,6 +4,14 @@ from cpt.packager import ConanMultiPackager
 
 
 if __name__ == "__main__":
-    builder = ConanMultiPackager()
+    builder = ConanMultiPackager(
+        username="reo7sp",
+        login_username="artalus", # change to bintray account
+        upload="https://api.bintray.com/conan/artalus/conan-public", # change to bintray api
+        channel="ci",
+        stable_branch_pattern="release/*",
+        upload_only_when_stable=True,  # Will only upload when the branch matches "release/*"
+        docker_32_images=True
+    )
     builder.add_common_builds()
     builder.run()

--- a/build.py
+++ b/build.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from cpt.packager import ConanMultiPackager
+
+
+if __name__ == "__main__":
+    builder = ConanMultiPackager()
+    builder.add_common_builds()
+    builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,61 @@
+
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class TgbotConan(ConanFile):
+    name = "tgbot_cpp"
+    version = "b35438d"
+    description = "C++ library for Telegram bot API"
+    url = "https://github.com/reo7sp/tgbot-cpp"
+    homepage = "http://reo7sp.github.io/tgbot-cpp"
+    license = "MIT"
+
+    exports_sources = ["LICENSE", ]
+    scm = {"type": "git",
+           "url": "auto",
+           "revision": "auto"}
+
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"fPIC": [True, False],
+               "shared": [True, False]}
+    default_options = {"fPIC": True, "shared": True}
+
+    requires = (
+        "boost/1.68.0@conan/stable",
+        "OpenSSL/1.0.2q@conan/stable",
+        "libcurl/7.61.1@bincrafters/stable"
+    )
+
+    def source(self):
+        boost_version = self.deps_cpp_info['boost'].version
+        tools.replace_in_file(os.path.join(self.source_folder, "CMakeLists.txt"),
+                              "find_package(Boost 1.59.0 COMPONENTS system REQUIRED)",
+                              "find_package(Boost {} COMPONENTS system REQUIRED)".format(boost_version))
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["ENABLE_TESTS"] = False
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ['TgBot']

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(PackageTest CXX)
+cmake_minimum_required(VERSION 2.8.4)
+set(CMAKE_CXX_STANDARD 11)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,25 @@
+
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,20 @@
+#include <tgbot/tgbot.h>
+
+using namespace std;
+using namespace TgBot;
+
+bool sigintGot = false;
+
+int main() {
+	Bot bot("PLACE YOUR TOKEN HERE");
+	bot.getEvents().onCommand("start", [&bot](Message::Ptr message) {
+		bot.getApi().sendMessage(message->chat->id, "Hi!");
+	});
+	bot.getEvents().onAnyMessage([&bot](Message::Ptr message) {
+		printf("User wrote %s\n", message->text.c_str());
+		if (StringTools::startsWith(message->text, "/start")) {
+			return;
+		}
+		bot.getApi().sendMessage(message->chat->id, "Your message is: " + message->text);
+	});
+}


### PR DESCRIPTION
@jgsogo iterated over my initial attempts to integrate tgbot with [conan.io](https://conan.io). I recommend merging this PR as a single squash, otherwise the commit graph might explode a bit :)

The package recipe is described in `conanfile.py`. See [docs tutorial](https://docs.conan.io/en/latest/creating_packages/getting_started.html#creating-the-package-recipe) and [conanfile reference](https://docs.conan.io/en/latest/reference/conanfile.html).

Conan packaging is integrated with CI. After unit tests in Docker are done, Travis and Appveyor will try to build a tgbot package from source for various OSes, compilers, runtimes and x86/x64 arch - check `appveyor.yml` and `.travis.yml` and `build.py`, using [conan package tools](https://github.com/conan-io/conan-package-tools) for reference.

You can notice that some builds have additional `CONAN_BUILD_POLICY=missing` envvar. This is needed for too old / too new compilers, where some dependencies are not present in prebuit form - check [conan docs](https://docs.conan.io/en/latest/mastering/policies.html) on policies. Building deps from scratch can take quite some time, so you can either 1) get rid of those builds entirely, or 2) try upload once-built dependencies to your repo on BinTray.

Conan will resolve dependencies as such:

        boost/1.68.0@conan/stable
        OpenSSL/1.0.2q@conan/stable
        libcurl/7.61.1@conan/stable

The package reference looks as this: `packagename/version@author/channel`. The `channel` is used to differentiate between, e.g.: a `stable` and widely used version of package or library; a `testing` version of a library release candidate, or package not yet entirely ready; a `ci` version of simply the last thing that was built from `master` branch.

Package uploading policy is described in `build.py`. You will need to create a [BinTray](https://bintray.com) account, and copy its API key (Edit profile -> API key) to `CONAN_PASSWORD` envvar in Appveyor and Travis. You will also need to change `login_username` and `upload` arguments in `build.py` to those of your BinTray.

Currently, the upload will happen only if the package is built on `release/*` branch (name is set in `build.py`). CI will create a package in `stable` channel and upload it to your BinTray. If you want the package to be uploaded after each and every build, you can set `upload_only_when_stable=False` - the package will be created in `ci` channel then.

Finally, a note about versions.

    version = "b35438d"
    scm = {"type": "git",
           "url": "auto",
           "revision": "auto"}

The `revision` set to `auto` will, [quote](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#scm), "capture the current working copy one" - which kind contradicts to a specific `version` set above. I am not quite sure what is the best option to maintain such a "rolling release" package. Perhaps one can use `version = master' or something like this, and release via branching to `release/0.1`, changing this to `verstion = 0.1` and then pushing the changes, so CI will get job done.