### PR TITLE
fix: use C++ fixed-width types instead of C types

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_API_H
 #define TGBOT_CPP_API_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -62,7 +63,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendMessage(int64_t chatId, const std::string& text, bool disableWebPagePreview = false, int32_t replyToMessageId = 0,
+    Message::Ptr sendMessage(std::int64_t chatId, const std::string& text, bool disableWebPagePreview = false, std::int32_t replyToMessageId = 0,
                              GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
@@ -73,7 +74,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr forwardMessage(int64_t chatId, int64_t fromChatId, int32_t messageId, bool disableNotification = false) const;
+    Message::Ptr forwardMessage(std::int64_t chatId, std::int64_t fromChatId, std::int32_t messageId, bool disableNotification = false) const;
 
     /**
      * @brief Use this method to send photos.
@@ -86,7 +87,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendPhoto(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> photo, const std::string& caption = "", int32_t replyToMessageId = 0,
+    Message::Ptr sendPhoto(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> photo, const std::string& caption = "", std::int32_t replyToMessageId = 0,
                            GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
@@ -104,8 +105,8 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendAudio(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> audio, const std::string &caption = "", int32_t duration = 0,
-                           const std::string& performer = "", const std::string& title = "", const boost::variant<InputFile::Ptr, std::string> thumb = "", int32_t replyToMessageId = 0,
+    Message::Ptr sendAudio(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> audio, const std::string &caption = "", std::int32_t duration = 0,
+                           const std::string& performer = "", const std::string& title = "", const boost::variant<InputFile::Ptr, std::string> thumb = "", std::int32_t replyToMessageId = 0,
                            GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
@@ -120,7 +121,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendDocument(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> document, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string &caption = "", int32_t replyToMessageId = 0,
+    Message::Ptr sendDocument(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> document, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string &caption = "", std::int32_t replyToMessageId = 0,
                               GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
@@ -150,13 +151,13 @@ public:
      * @param disableNotification Optional. Sends the message silently. Users will receive a notification with no sound.
      * @return On success, the sent Message is returned.
      */
-    Message::Ptr sendInvoice(int64_t chatId, const std::string& title, const std::string& description, const std::string& payload,
+    Message::Ptr sendInvoice(std::int64_t chatId, const std::string& title, const std::string& description, const std::string& payload,
                              const std::string& providerToken, const std::string& startParameter, const std::string& currency, const std::vector<LabeledPrice::Ptr>& prices,
-                             const std::string& providerData = "", const std::string& photoUrl = "", int32_t photoSize = 0,
-                             int32_t photoWidth = 0, int32_t photoHeight = 0, bool needName = false,
+                             const std::string& providerData = "", const std::string& photoUrl = "", std::int32_t photoSize = 0,
+                             std::int32_t photoWidth = 0, std::int32_t photoHeight = 0, bool needName = false,
                              bool needPhoneNumber = false, bool needEmail = false, bool needShippingAddress = false,
                              bool sendPhoneNumberToProvider = false, bool sendEmailToProvider = false, bool isFlexible = false,
-                             int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+                             std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
 
     /**
      * @brief Use this method to reply to shipping queries.
@@ -193,7 +194,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendSticker(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> sticker, int32_t replyToMessageId = 0,
+    Message::Ptr sendSticker(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> sticker, std::int32_t replyToMessageId = 0,
                              GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
 
     /**
@@ -209,7 +210,7 @@ public:
      * @param pngSticker Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px.
      * @return Returns the uploaded File on success.
      */
-    File::Ptr uploadStickerFile(int32_t userId, InputFile::Ptr pngSticker) const;
+    File::Ptr uploadStickerFile(std::int32_t userId, InputFile::Ptr pngSticker) const;
 
     /**
      * @brief Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
@@ -222,7 +223,7 @@ public:
      * @param maskPosition Optional. A JSON-serialized object for position where the mask should be placed on faces.
      * @return Returns True on success.
      */
-    bool createNewStickerSet(int32_t userId, const std::string& name, const std::string& title,
+    bool createNewStickerSet(std::int32_t userId, const std::string& name, const std::string& title,
                              boost::variant<InputFile::Ptr, std::string> pngSticker, const std::string& emojis, bool containsMasks = false, MaskPosition::Ptr maskPosition = nullptr) const;
 
     /**
@@ -234,7 +235,7 @@ public:
      * @param maskPosition Optional. A JSON-serialized object for position where the mask should be placed on faces.
      * @return Returns True on success.
      */
-    bool addStickerToSet(int32_t userId, const std::string& name,
+    bool addStickerToSet(std::int32_t userId, const std::string& name,
                          boost::variant<InputFile::Ptr, std::string> pngSticker, const std::string& emojis, MaskPosition::Ptr maskPosition = nullptr) const;
 
     /**
@@ -243,7 +244,7 @@ public:
      * @param position New sticker position in the set, zero-based.
      * @return Returns True on success.
      */
-    bool setStickerPositionInSet(const std::string& sticker, uint32_t position) const;
+    bool setStickerPositionInSet(const std::string& sticker, std::uint32_t position) const;
 
     /**
      * @brief Use this method to delete a sticker from a set created by the bot.
@@ -269,8 +270,8 @@ public:
      * @return On success, the sent message is returned.
      */
 
-    Message::Ptr sendVideo(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> video, bool supportsStreaming = false, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string& caption = "",
-                           int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
+    Message::Ptr sendVideo(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> video, bool supportsStreaming = false, std::int32_t duration = 0, std::int32_t width = 0, std::int32_t height = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string& caption = "",
+                           std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
      * @brief Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound).
@@ -290,8 +291,8 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent Message is returned.
      */
-    Message::Ptr sendAnimation(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> animation, int32_t duration = 0, int32_t width = 0, int32_t height = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string &caption = "",
-                              int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
+    Message::Ptr sendAnimation(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> animation, std::int32_t duration = 0, std::int32_t width = 0, std::int32_t height = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", const std::string &caption = "",
+                              std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
     /**
      * @brief Use this method to send video messages. On success, the sent Message is returned.
      * @param chatId Unique identifier for the target chat.
@@ -304,8 +305,8 @@ public:
      * @param replyMarkup Additional interface options. A object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.
      * @return On success, the sent Message is returned.
      */
-    Message::Ptr sendVideoNote(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> videoNote, int64_t replyToMessageId = 0, bool disableNotification = false,
-                               int32_t duration = 0, int32_t length = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
+    Message::Ptr sendVideoNote(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> videoNote, std::int64_t replyToMessageId = 0, bool disableNotification = false,
+                               std::int32_t duration = 0, std::int32_t length = 0, const boost::variant<InputFile::Ptr, std::string> thumb = "", GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
      * @brief Use this method to send a group of photos or videos as an album.
@@ -315,8 +316,8 @@ public:
      * @param replyToMessageId Optional. If the messages are a reply, ID of the original message.
      * @return On success, an array of the sent Messages is returned.
      */
-    std::vector<Message::Ptr> sendMediaGroup(int64_t chatId, const std::vector<InputMedia::Ptr>& media,
-                                             bool disableNotification = false, int32_t replyToMessageId = 0) const;
+    std::vector<Message::Ptr> sendMediaGroup(std::int64_t chatId, const std::vector<InputMedia::Ptr>& media,
+                                             bool disableNotification = false, std::int32_t replyToMessageId = 0) const;
 
     /**
      * @brief Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message.
@@ -330,7 +331,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendVoice(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> voice, const std::string& caption = "", int duration = 0, int32_t replyToMessageId = 0,
+    Message::Ptr sendVoice(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> voice, const std::string& caption = "", int duration = 0, std::int32_t replyToMessageId = 0,
                            GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), const std::string& parseMode = "", bool disableNotification = false) const;
 
     /**
@@ -342,7 +343,7 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendGame(int64_t chatId, const std::string& gameShortName, int32_t replyToMessageId = 0,
+    Message::Ptr sendGame(std::int64_t chatId, const std::string& gameShortName, std::int32_t replyToMessageId = 0,
                           InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>(), bool disableNotification = false) const;
 
     /**
@@ -356,8 +357,8 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendLocation(int64_t chatId, float latitude, float longitude, uint32_t livePeriod = 0,
-                              int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
+    Message::Ptr sendLocation(std::int64_t chatId, float latitude, float longitude, std::uint32_t livePeriod = 0,
+                              std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>(), bool disableNotification = false) const;
 
     /**
      * @brief Use this method to edit live location messages sent by the bot or via the bot (for inline bots).
@@ -369,8 +370,8 @@ public:
      * @param replyMarkup Optional. A JSON-serialized object for a new inline keyboard.
      * @return On success, if the edited message was sent by the bot, the edited Message is returned, otherwise nullptr is returned.
      */
-    Message::Ptr editMessageLiveLocation(float latitude, float longitude, int64_t chatId = 0, int32_t messageId = 0,
-                                         int32_t inlineMessageId = 0, InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>()) const;
+    Message::Ptr editMessageLiveLocation(float latitude, float longitude, std::int64_t chatId = 0, std::int32_t messageId = 0,
+                                         std::int32_t inlineMessageId = 0, InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>()) const;
 
     /**
      * @brief Use this method to edit live location messages sent by the bot or via the bot (for inline bots).
@@ -380,7 +381,7 @@ public:
      * @param replyMarkup Optional. A JSON-serialized object for a new inline keyboard.
      * @return On success, if the edited message was sent by the bot, the edited Message is returned, otherwise nullptr is returned.
      */
-    Message::Ptr stopMessageLiveLocation(int64_t chatId = 0, int32_t messageId = 0, int32_t inlineMessageId = 0,
+    Message::Ptr stopMessageLiveLocation(std::int64_t chatId = 0, std::int32_t messageId = 0, std::int32_t inlineMessageId = 0,
                                          InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>()) const;
 
 
@@ -398,8 +399,8 @@ public:
      * @param disableNotification Optional. Sends the message silenty.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendVenue(int64_t chatId, float latitude, float longitude, const std::string& title, const std::string& address, const std::string& foursquareId = "", const std::string& foursquareType = "",
-                           bool disableNotification = false, int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
+    Message::Ptr sendVenue(std::int64_t chatId, float latitude, float longitude, const std::string& title, const std::string& address, const std::string& foursquareId = "", const std::string& foursquareType = "",
+                           bool disableNotification = false, std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
      * @brief Use this method to send phone contacts. On success, the sent Message is returned.
@@ -413,8 +414,8 @@ public:
      * @param replyMarkup Optional. Additional interface options. A object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
      * @return On success, the sent message is returned.
      */
-    Message::Ptr sendContact(int64_t chatId, const std::string& phoneNumber, const std::string& firstName, const std::string& lastName = "", const std::string& vcard = "", bool disableNotification = false,
-                            int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
+    Message::Ptr sendContact(std::int64_t chatId, const std::string& phoneNumber, const std::string& firstName, const std::string& lastName = "", const std::string& vcard = "", bool disableNotification = false,
+                            std::int32_t replyToMessageId = 0, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
      * @brief Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status).
@@ -425,7 +426,7 @@ public:
      * @param chatId Unique identifier for the target chat.
      * @param action Type of action to broadcast. Choose one, depending on what the user is about to receive: typing for text messages, upload_photo for photos, record_video or upload_video for videos, record_audio or upload_audio for audio files, upload_document for general files, find_location for location data.
      */
-    void sendChatAction(int64_t chatId, const std::string& action) const;
+    void sendChatAction(std::int64_t chatId, const std::string& action) const;
 
     /**
      * @brief Use this method to get a list of profile pictures for a user.
@@ -434,7 +435,7 @@ public:
      * @param limit Optional. Limits the number of photos to be retrieved. Values between 1—100 are accepted. Defaults to 100.
      * @return A UserProfilePhotos object.
      */
-    UserProfilePhotos::Ptr getUserProfilePhotos(int32_t userId, int32_t offset = 0, int32_t limit = 100) const;
+    UserProfilePhotos::Ptr getUserProfilePhotos(std::int32_t userId, std::int32_t offset = 0, std::int32_t limit = 100) const;
 
     /**
      * @brief Use this method to get basic info about a file and prepare it for downloading. For the moment, bots can download files of up to 20MB in size.
@@ -448,28 +449,28 @@ public:
      * @param chatId Unique identifier for the target chat of the target supergroup or channel.
      * @return True on success
      */
-    bool leaveChat(int64_t chatId) const;
+    bool leaveChat(std::int64_t chatId) const;
 
     /**
      * @brief Use this method to get up to date information about the chat (current name of the user for one-on-one conversations, current username of a user, group or channel, etc.). Returns a Chat object on success.
      * @param chatId Unique identifier for the target chat of the target supergroup or channel.
      * @return Chat object.
      */
-    Chat::Ptr getChat(int64_t chatId) const;
+    Chat::Ptr getChat(std::int64_t chatId) const;
 
     /**
     * @brief Use this method to get a list of administrators in a chat. On success, returns an Array of ChatMember objects that contains information about all chat administrators except other bots. If the chat is a group or a supergroup and no administrators were appointed, only the creator will be returned.
     * @param chatId Unique identifier for the target chat of the target supergroup or channel.
     * @return ChatMember object.
     */
-    std::vector<ChatMember::Ptr> getChatAdministrators(int64_t chatId) const;
+    std::vector<ChatMember::Ptr> getChatAdministrators(std::int64_t chatId) const;
 
     /**
     * @brief Use this method to get the number of members in a chat. Returns Int on success.
     * @param chatId Unique identifier for the target chat of the target supergroup or channel.
     * @return Int.
     */
-    int32_t getChatMembersCount(int64_t chatId) const;
+    std::int32_t getChatMembersCount(std::int64_t chatId) const;
 
     /**
     * @brief Use this method to get information about a member of a chat. Returns a ChatMember object on success.
@@ -477,7 +478,7 @@ public:
     * @param userId Unique identifier of the target user
     * @return ChatMember object.
     */
-    ChatMember::Ptr getChatMember(int64_t chatId, int32_t userId) const;
+    ChatMember::Ptr getChatMember(std::int64_t chatId, std::int32_t userId) const;
 
     /**
     * @brief Use this method to get information about a member of a chat. Returns a ChatMember object on success.
@@ -485,14 +486,14 @@ public:
     * @param stickerSetName Name of the sticker set to be set as the group sticker set.
     * @return Returns True on success.
     */
-    bool setChatStickerSet(int64_t chatId, const std::string& stickerSetName) const;
+    bool setChatStickerSet(std::int64_t chatId, const std::string& stickerSetName) const;
 
     /**
     * @brief Use this method to get information about a member of a chat. Returns a ChatMember object on success.
     * @param chatId Unique identifier for the target chat of the target supergroup or channel.
     * @return Returns True on success.
     */
-    bool deleteChatStickerSet(int64_t chatId) const;
+    bool deleteChatStickerSet(std::int64_t chatId) const;
 
 
     /**
@@ -504,7 +505,7 @@ public:
      * @param cacheTime Optional	The maximum amount of time in seconds that the result of the callback query may be cached client-side. Telegram apps will support caching starting in version 3.14. Defaults to 0.
      * @return True on success
      */
-    bool answerCallbackQuery(const std::string & callbackQueryId, const std::string & text="", bool showAlert=false, const std::string &url="", int32_t cacheTime=0) const;
+    bool answerCallbackQuery(const std::string & callbackQueryId, const std::string & text="", bool showAlert=false, const std::string &url="", std::int32_t cacheTime=0) const;
 
     /**
      * @brief Use this method to edit text and game messages sent by the bot or via the bot (for inline bots)
@@ -517,7 +518,7 @@ public:
      * @param replyMarkup Optional	A JSON-serialized object for an inline keyboard.
      * @return Message object on success, otherwise nullptr
      */
-    Message::Ptr editMessageText(const std::string& text, int64_t chatId=0, int32_t messageId=0, const std::string& inlineMessageId="",
+    Message::Ptr editMessageText(const std::string& text, std::int64_t chatId=0, std::int32_t messageId=0, const std::string& inlineMessageId="",
                                  const std::string& parseMode = "", bool disableWebPagePreview = false, GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
@@ -529,7 +530,7 @@ public:
     * @param replyMarkup Optional	A JSON-serialized object for an inline keyboard.
     * @return Message object on success, otherwise nullptr
     */
-    Message::Ptr editMessageCaption(int64_t chatId = 0, int32_t messageId = 0, const std::string& caption = "",
+    Message::Ptr editMessageCaption(std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& caption = "",
                                     const std::string& inlineMessageId = "", GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
@@ -547,7 +548,7 @@ public:
      * @param replyMarkup Optional	A JSON-serialized object for an inline keyboard.
      * @return On success, if the edited message was sent by the bot, the edited Message is returned, otherwise nullptr is returned.
      */
-    Message::Ptr editMessageMedia(InputMedia::Ptr media, int64_t chatId = 0, int32_t messageId = 0, const std::string& inlineMessageId = "",
+    Message::Ptr editMessageMedia(InputMedia::Ptr media, std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "",
                                   GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
@@ -558,7 +559,7 @@ public:
     * @param replyMarkup Optional	A JSON-serialized object for an inline keyboard.
     * @return Message object on success, otherwise nullptr
     */
-    Message::Ptr editMessageReplyMarkup(int64_t chatId = 0, int32_t messageId = 0, const std::string& inlineMessageId = "",
+    Message::Ptr editMessageReplyMarkup(std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "",
                                         const GenericReply::Ptr replyMarkup = std::make_shared<GenericReply>()) const;
 
     /**
@@ -566,7 +567,7 @@ public:
      * @param chatId	Unique identifier for the target chat or username of the target channel.
      * @param messageId	Unique identifier for the target message.
      */
-    void deleteMessage(int64_t chatId, int32_t messageId) const;
+    void deleteMessage(std::int64_t chatId, std::int32_t messageId) const;
 
     /**
      * @brief Use this method to receive incoming updates using long polling.
@@ -580,7 +581,7 @@ public:
      * @param allowed_updates Optional. List the types of updates you want your bot to receive. For example, specify [“message”, “edited_channel_post”, “callback_query”] to only receive updates of these types. See Update for a complete list of available update types. Specify an empty list to receive all updates regardless of type (default). If not specified, the previous setting will be used.
      * @return An Array of Update objects
      */
-    std::vector<Update::Ptr> getUpdates(int32_t offset = 0, int32_t limit = 100, int32_t timeout = 0, const StringArrayPtr &allowedUpdates = nullptr) const;
+    std::vector<Update::Ptr> getUpdates(std::int32_t offset = 0, std::int32_t limit = 100, std::int32_t timeout = 0, const StringArrayPtr &allowedUpdates = nullptr) const;
 
     /**
      * @brief Use this method to specify a url and receive incoming updates via an outgoing webhook. Whenever there is an update for the bot, we will send an HTTPS POST request to the specified url, containing a JSON-serialized Update. In case of an unsuccessful request, we will give up after a reasonable amount of attempts.
@@ -592,7 +593,7 @@ public:
      *
      * @param url Optional. HTTPS url to send updates to. Use an empty string to remove webhook integration.
      */
-    void setWebhook(const std::string& url = "", InputFile::Ptr certificate = nullptr, int32_t maxConnection = 40, const StringArrayPtr &allowedUpdates = nullptr) const;
+    void setWebhook(const std::string& url = "", InputFile::Ptr certificate = nullptr, std::int32_t maxConnection = 40, const StringArrayPtr &allowedUpdates = nullptr) const;
 
     /**
      * @brief Use this method to remove webhook integration if you decide to switch back to getUpdates.
@@ -626,7 +627,7 @@ public:
      * @return True on success
      */
     bool answerInlineQuery(const std::string& inlineQueryId, const std::vector<InlineQueryResult::Ptr>& results,
-                            int32_t cacheTime = 300, bool isPersonal = false, const std::string& nextOffset = "", const std::string& switchPmText = "", const std::string& switchPmParameter = "") const;
+                            std::int32_t cacheTime = 300, bool isPersonal = false, const std::string& nextOffset = "", const std::string& switchPmText = "", const std::string& switchPmParameter = "") const;
 
     /**
      * @brief Use this method to kick a user from a group or a supergroup.
@@ -635,7 +636,7 @@ public:
      * @param untilDate Optional. Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever.
      * @return True on success
      */
-    bool kickChatMember(int64_t chatId, int32_t userId, uint64_t untilDate = 0) const;
+    bool kickChatMember(std::int64_t chatId, std::int32_t userId, std::uint64_t untilDate = 0) const;
 
     /**
      * @brief Use this method to unban a previously kicked user in a supergroup.
@@ -643,7 +644,7 @@ public:
      * @param userId Unique identifier of the target user.
      * @return True on success
      */
-    bool unbanChatMember(int64_t chatId, int32_t userId) const;
+    bool unbanChatMember(std::int64_t chatId, std::int32_t userId) const;
 
     /**
      * @brief Use this method to restrict a user in a supergroup.
@@ -656,7 +657,7 @@ public:
      * @param canAddWebPagePreviews Optional. Pass True, if the user may add web page previews to their messages, implies can_send_media_messages.
      * @return True on success
      */
-    bool restrictChatMember(int64_t chatId, int32_t userId, ChatPermissions::Ptr permissions, uint64_t untilDate = 0) const;
+    bool restrictChatMember(std::int64_t chatId, std::int32_t userId, ChatPermissions::Ptr permissions, std::uint64_t untilDate = 0) const;
 
     /**
      * @brief Use this method to promote or demote a user in a supergroup or a channel.
@@ -672,7 +673,7 @@ public:
      * @param canPromoteMembers Optional. Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him).
      * @return True on success
      */
-    bool promoteChatMember(int64_t chatId, int32_t userId, bool canChangeInfo = false, bool canPostMessages = false,
+    bool promoteChatMember(std::int64_t chatId, std::int32_t userId, bool canChangeInfo = false, bool canPostMessages = false,
                            bool canEditMessages = false, bool canDeleteMessages = false, bool canInviteUsers = false, bool canPinMessages = false, bool canPromoteMembers = false) const;
 
     /**
@@ -681,14 +682,14 @@ public:
   * @param permissions New default chat permissions.
   * @return True on success
   */
-    bool setChatPermissions(int64_t chatId, ChatPermissions::Ptr permissions) const;
+    bool setChatPermissions(std::int64_t chatId, ChatPermissions::Ptr permissions) const;
 
     /**
      * @brief Use this method to generate a new invite link for a chat; any previously generated link is revoked.
      * @param chatId Unique identifier for the target chat.
      * @return The new invite link as String on success.
      */
-    std::string exportChatInviteLink(int64_t chatId) const;
+    std::string exportChatInviteLink(std::int64_t chatId) const;
 
     /**
      * @brief Use this method to set a new profile photo for the chat.
@@ -699,7 +700,7 @@ public:
      * @param photo New chat photo.
      * @return True on success
      */
-    bool setChatPhoto(int64_t chatId, InputFile::Ptr photo) const;
+    bool setChatPhoto(std::int64_t chatId, InputFile::Ptr photo) const;
 
     /**
      * @brief Use this method to delete a chat photo.
@@ -709,7 +710,7 @@ public:
      * @param chatId Unique identifier for the target chat.
      * @return True on success
      */
-    bool deleteChatPhoto(int64_t chatId) const;
+    bool deleteChatPhoto(std::int64_t chatId) const;
 
     /**
      * @brief Use this method to change the title of a chat.
@@ -720,7 +721,7 @@ public:
      * @param title New chat title, 1-255 characters.
      * @return True on success
      */
-    bool setChatTitle(int64_t chatId, const std::string& title) const;
+    bool setChatTitle(std::int64_t chatId, const std::string& title) const;
 
     /**
      * @brief Use this method to change the description of a supergroup or a channel.
@@ -728,7 +729,7 @@ public:
      * @param description New chat description, 1-255 characters.
      * @return True on success
      */
-    bool setChatDescription(int64_t chatId, const std::string& description) const;
+    bool setChatDescription(std::int64_t chatId, const std::string& description) const;
 
     /**
      * @brief Use this method to pin a message in a group, a supergroup, or a channel.
@@ -737,14 +738,14 @@ public:
      * @param disableNotification Optional. Pass True, if it is not necessary to send a notification to all chat members about the new pinned message. Notifications are always disabled in channels.
      * @return True on success
      */
-    bool pinChatMessage(int64_t chatId, int32_t messageId, bool disableNotification = false) const;
+    bool pinChatMessage(std::int64_t chatId, std::int32_t messageId, bool disableNotification = false) const;
 
     /**
      * @brief Use this method to unpin a message in a group, a supergroup, or a channel.
      * @param chatId Unique identifier for the target chat or username of the target channel.
      * @return True on success
      */
-    bool unpinChatMessage(int64_t chatId) const;
+    bool unpinChatMessage(std::int64_t chatId) const;
 
     /**
      * @brief Use this method to set the score of the specified user in a game.
@@ -760,8 +761,8 @@ public:
      * @param inlineMessageId Optional. Required if chatId and messageId are not specified. Identifier of the inline message
      * @return On success, if the message was sent by the bot, returns the edited Message, otherwise returns nullptr.
      */
-    Message::Ptr setGameScore(int32_t userId, int32_t score, bool force = false, bool disableEditMessage = false,
-                              int64_t chatId = 0, int32_t messageId = 0, const std::string& inlineMessageId = "") const;
+    Message::Ptr setGameScore(std::int32_t userId, std::int32_t score, bool force = false, bool disableEditMessage = false,
+                              std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "") const;
 
     /**
      * @brief Use this method to get data for high score tables.
@@ -774,8 +775,8 @@ public:
      * @param inlineMessageId Optional. Required if chatId and messageId are not specified. Identifier of the inline message
      * @return On success, returns an Array of GameHighScore objects.
      */
-    std::vector<GameHighScore::Ptr> getGameHighScores(int32_t userId, int32_t score, bool force = false,
-                                                      bool disableEditMessage = false, int64_t chatId = 0, int32_t messageId = 0, const std::string& inlineMessageId = "") const;
+    std::vector<GameHighScore::Ptr> getGameHighScores(std::int32_t userId, std::int32_t score, bool force = false,
+                                                      bool disableEditMessage = false, std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "") const;
 
     /**
      * @brief Downloads file from Telegram and saves it in memory.
@@ -796,7 +797,7 @@ public:
     *
     * @return On success, the sent message is returned.
     */
-    Message::Ptr sendPoll(int64_t chatId, std::string question, std::vector<std::string> options, bool disable_notification=false, int32_t reply_to_message_id=0,GenericReply::Ptr reply_markup = std::make_shared<GenericReply>()) const;
+    Message::Ptr sendPoll(std::int64_t chatId, std::string question, std::vector<std::string> options, bool disable_notification=false, std::int32_t reply_to_message_id=0,GenericReply::Ptr reply_markup = std::make_shared<GenericReply>()) const;
 
     /**
     * @brief Use this method to stop a poll which was sent by the bot. On success, the stopped Poll with the final results is returned..
@@ -810,7 +811,7 @@ public:
     * @return On success, the sent message is returned.
     */
 
-    Poll::Ptr stopPoll(int64_t chatId, int64_t messageId, InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>()) const;
+    Poll::Ptr stopPoll(std::int64_t chatId, std::int64_t messageId, InlineKeyboardMarkup::Ptr replyMarkup = std::make_shared<InlineKeyboardMarkup>()) const;
 
 private:
     boost::property_tree::ptree sendRequest(const std::string& method, const std::vector<HttpReqArg>& args = std::vector<HttpReqArg>()) const;

--- a/include/tgbot/net/HttpServer.h
+++ b/include/tgbot/net/HttpServer.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_HTTPSERVER_H
 #define TGBOT_HTTPSERVER_H
 
+#include <cstddef>
 #include <iostream>
 #include <string>
 #include <utility>
@@ -73,7 +74,7 @@ protected:
                     _socket,
                     *data,
                     "\r\n\r\n",
-                    [self, data](const boost::system::error_code& e, size_t n) {
+                    [self, data](const boost::system::error_code& e, std::size_t n) {
                 if (e) {
                     std::cout << "error in HttpServer::Connection#_readHeader: " << e << std::endl;
                     return;
@@ -97,7 +98,7 @@ protected:
                     boost::asio::async_write(
                             self->_socket,
                             boost::asio::buffer(answer),
-                            [](const boost::system::error_code& e, size_t n) { });
+                            [](const boost::system::error_code& e, std::size_t n) { });
                     return;
                 }
 
@@ -114,7 +115,7 @@ protected:
             boost::asio::async_read(_socket,
                                     *data,
                                     boost::asio::transfer_exactly(size - data->size()),
-                                    [self, data, size, headers](const boost::system::error_code& e, size_t n) {
+                                    [self, data, size, headers](const boost::system::error_code& e, std::size_t n) {
                 if (e) {
                     std::cout << "error in HttpServer::Connection#_readBody: " << e << std::endl;
                     return;
@@ -133,7 +134,7 @@ protected:
                 boost::asio::async_write(
                         self->_socket,
                         boost::asio::buffer(answer),
-                        [](const boost::system::error_code& e, size_t n) { });
+                        [](const boost::system::error_code& e, std::size_t n) { });
 
                 self->_socket.close();
             });

--- a/include/tgbot/net/TgLongPoll.h
+++ b/include/tgbot/net/TgLongPoll.h
@@ -1,6 +1,8 @@
 #ifndef TGBOT_TGLONGPOLL_H
 #define TGBOT_TGLONGPOLL_H
 
+#include <cstdint>
+
 #include "tgbot/Bot.h"
 #include "tgbot/Api.h"
 #include "tgbot/EventHandler.h"
@@ -15,8 +17,8 @@ namespace TgBot {
 class TgLongPoll {
 
 public:
-    TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t, int32_t, const std::shared_ptr<std::vector<std::string>>&);
-    TgLongPoll(const Bot& bot, int32_t = 100, int32_t = 10, const std::shared_ptr<std::vector<std::string>>& = nullptr);
+    TgLongPoll(const Api* api, const EventHandler* eventHandler, std::int32_t, std::int32_t, const std::shared_ptr<std::vector<std::string>>&);
+    TgLongPoll(const Bot& bot, std::int32_t = 100, std::int32_t = 10, const std::shared_ptr<std::vector<std::string>>& = nullptr);
 
     /**
      * @brief Starts long poll. After new update will come, this method will parse it and send to EventHandler which invokes your listeners. Designed to be executed in a loop.
@@ -26,9 +28,9 @@ public:
 private:
     const Api* _api;
     const EventHandler* _eventHandler;
-    int32_t _lastUpdateId = 0;
-    int32_t _limit;
-    int32_t _timeout;
+    std::int32_t _lastUpdateId = 0;
+    std::int32_t _limit;
+    std::int32_t _timeout;
     std::shared_ptr<std::vector<std::string>> _allowupdates;
 };
 

--- a/include/tgbot/tools/StringTools.h
+++ b/include/tgbot/tools/StringTools.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_STRINGTOOLS_H
 #define TGBOT_CPP_STRINGTOOLS_H
 
+#include <cstddef>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -36,7 +37,7 @@ void split(const std::string& str, char delimiter, std::vector<std::string>& des
  * Generates pseudo random string. It's recommended to call srand before this method.
  * @param length Length of resulting string.
  */
-std::string generateRandomString(size_t length);
+std::string generateRandomString(std::size_t length);
 
 /**
  * Performs url encode.

--- a/include/tgbot/types/Animation.h
+++ b/include/tgbot/types/Animation.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_ANIMATION_H
 #define TGBOT_ANIMATION_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -42,7 +43,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 }
 

--- a/include/tgbot/types/Audio.h
+++ b/include/tgbot/types/Audio.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_AUDIO_H
 #define TGBOT_CPP_AUDIO_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -26,7 +27,7 @@ public:
     /**
      * @brief Duration of the audio in seconds as defined by sender.
      */
-    int32_t duration;
+    std::int32_t duration;
 
     /**
      * @brief Optional. Performer of the audio as defined by sender
@@ -48,7 +49,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 
     /**
      * @brief Optional. Thumbnail of the album cover to which the music file belongs

--- a/include/tgbot/types/Chat.h
+++ b/include/tgbot/types/Chat.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_CHAT_H
 #define TGBOT_CPP_CHAT_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -29,7 +30,7 @@ public:
     /**
      * @brief Unique identifier for this chat, not exceeding 1e13 by absolute value
      */
-    int64_t id;
+    std::int64_t id;
 
     /**
      * @brief Type of chat: can be either "private", "group", "supergroup, or "channel".

--- a/include/tgbot/types/ChatMember.h
+++ b/include/tgbot/types/ChatMember.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CHATMEMBER_H
 #define TGBOT_CHATMEMBER_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -29,7 +30,7 @@ public:
     /**
      * @brief Optional. Restricted and kicked only. Date when restrictions will be lifted for this user, unix time.
      */
-    uint64_t untilDate;
+    std::uint64_t untilDate;
 
     /**
      * @brief Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user.

--- a/include/tgbot/types/Document.h
+++ b/include/tgbot/types/Document.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_DOCUMENT_H
 #define TGBOT_CPP_DOCUMENT_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -41,7 +42,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 
 }

--- a/include/tgbot/types/File.h
+++ b/include/tgbot/types/File.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_FILE_H
 #define TGBOT_CPP_FILE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -29,7 +30,7 @@ public:
     /**
      * @brief Optional. File size, if known
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 
     /**
      * @brief Optional. File path.

--- a/include/tgbot/types/GameHighScore.h
+++ b/include/tgbot/types/GameHighScore.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_GAMEHIGHSCORE_H
 #define TGBOT_GAMEHIGHSCORE_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -31,7 +32,7 @@ public:
     /**
      * @brief Score.
      */
-    int32_t score;
+    std::int32_t score;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultArticle.h
+++ b/include/tgbot/types/InlineQueryResultArticle.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTARTICLE_H
 #define TGBOT_INLINEQUERYRESULTARTICLE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -49,12 +50,12 @@ public:
     /**
      * @brief Optional. Thumbnail width.
      */
-    int32_t thumbWidth;
+    std::int32_t thumbWidth;
 
     /**
      * @brief Optinal. Thumbnail height
      */
-    int32_t thumbHeight;
+    std::int32_t thumbHeight;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultAudio.h
+++ b/include/tgbot/types/InlineQueryResultAudio.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTAUDIO_H
 #define TGBOT_INLINEQUERYRESULTAUDIO_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -37,7 +38,7 @@ public:
     /**
     * @brief Optional. Audio duration in seconds
     */
-    int32_t audioDuration;
+    std::int32_t audioDuration;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultContact.h
+++ b/include/tgbot/types/InlineQueryResultContact.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTCONTACT_H
 #define TGBOT_INLINEQUERYRESULTCONTACT_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -53,12 +54,12 @@ public:
     /**
     * @brief Optional. Thumbnail width.
     */
-    int32_t thumbWidth;
+    std::int32_t thumbWidth;
 
     /**
     * @brief Optinal. Thumbnail height
     */
-    int32_t thumbHeight;
+    std::int32_t thumbHeight;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultDocument.h
+++ b/include/tgbot/types/InlineQueryResultDocument.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTDOCUMENT_H
 #define TGBOT_INLINEQUERYRESULTDOCUMENT_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -48,12 +49,12 @@ public:
     /**
     * @brief Optional. Thumbnail width.
     */
-    int32_t thumbWidth;
+    std::int32_t thumbWidth;
 
     /**
     * @brief Optinal. Thumbnail height
     */
-    int32_t thumbHeight;
+    std::int32_t thumbHeight;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultGif.h
+++ b/include/tgbot/types/InlineQueryResultGif.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTGIF_H
 #define TGBOT_INLINEQUERYRESULTGIF_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -33,17 +34,17 @@ public:
     /**
      * @brief Optional. Width of the GIF.
      */
-    int32_t gifWidth;
+    std::int32_t gifWidth;
 
     /**
      * @brief Optional. Height of the GIF.
      */
-    int32_t gifHeight;
+    std::int32_t gifHeight;
 
     /**
      * @brief Optional. Duration of the GIF
      */
-    int32_t gifDuration;
+    std::int32_t gifDuration;
 
     /**
      * @brief URL of the static thumbnail for the result (jpeg or gif)

--- a/include/tgbot/types/InlineQueryResultLocation.h
+++ b/include/tgbot/types/InlineQueryResultLocation.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTLOCATION_H
 #define TGBOT_INLINEQUERYRESULTLOCATION_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -43,12 +44,12 @@ public:
     /**
      * @brief Optional. Thumbnail width.
      */
-    int32_t thumbWidth;
+    std::int32_t thumbWidth;
 
     /**
      * @brief Optinal. Thumbnail height
      */
-    int32_t thumbHeight;
+    std::int32_t thumbHeight;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultMpeg4Gif.h
+++ b/include/tgbot/types/InlineQueryResultMpeg4Gif.h
@@ -1,6 +1,10 @@
 #ifndef TGBOT_INLINEQUERYRESULTMPEG4GIF_H
 #define TGBOT_INLINEQUERYRESULTMPEG4GIF_H
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 namespace TgBot {
 
 /**
@@ -28,17 +32,17 @@ public:
     /**
      * @brief Optional. Video width.
      */
-    int32_t mpeg4Width;
+    std::int32_t mpeg4Width;
 
     /**
      * @brief Optional. Video height.
      */
-    int32_t mpeg4Height;
+    std::int32_t mpeg4Height;
 
     /**
      * @brief Optional. Video duration.
      */
-    int32_t mpeg4Duration;
+    std::int32_t mpeg4Duration;
 
     /**
     * @brief URL of the static thumbnail (jpeg or gif) for the result

--- a/include/tgbot/types/InlineQueryResultPhoto.h
+++ b/include/tgbot/types/InlineQueryResultPhoto.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTPHOTO_H
 #define TGBOT_INLINEQUERYRESULTPHOTO_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -38,12 +39,12 @@ public:
     /**
      * @brief Optional. Width of the photo.
      */
-    int32_t photoWidth;
+    std::int32_t photoWidth;
 
     /**
      * @brief Optional. Height of the photo.
      */
-    int32_t photoHeight;
+    std::int32_t photoHeight;
 
     /**
      * @brief Optional. Short description of the result.

--- a/include/tgbot/types/InlineQueryResultVenue.h
+++ b/include/tgbot/types/InlineQueryResultVenue.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INLINEQUERYRESULTVENUE_H
 #define TGBOT_INLINEQUERYRESULTVENUE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -58,12 +59,12 @@ public:
     /**
      * @brief Optional. Thumbnail width.
      */
-    int32_t thumbWidth;
+    std::int32_t thumbWidth;
 
     /**
      * @brief Optinal. Thumbnail height
      */
-    int32_t thumbHeight;
+    std::int32_t thumbHeight;
 };
 }
 

--- a/include/tgbot/types/InlineQueryResultVideo.h
+++ b/include/tgbot/types/InlineQueryResultVideo.h
@@ -1,6 +1,10 @@
 #ifndef TGBOT_INLINEQUERYRESULTVIDEO_H
 #define TGBOT_INLINEQUERYRESULTVIDEO_H
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 namespace TgBot {
 
 /**
@@ -39,17 +43,17 @@ public:
     /**
      * @brief Optional. Video width.
      */
-    int32_t videoWidth;
+    std::int32_t videoWidth;
 
     /**
      * @brief Optional. Video height.
      */
-    int32_t videoHeight;
+    std::int32_t videoHeight;
 
     /**
      * @brief Optional. Video duration.
      */
-    int32_t videoDuration;
+    std::int32_t videoDuration;
 
     /**
      * @brief Optional. Short description of the result.

--- a/include/tgbot/types/InlineQueryResultVoice.h
+++ b/include/tgbot/types/InlineQueryResultVoice.h
@@ -1,6 +1,10 @@
 #ifndef TGBOT_INLINEQUERYRESULTVOICE_H
 #define TGBOT_INLINEQUERYRESULTVOICE_H
 
+#include <cstdint>
+#include <memory>
+#include <string>
+
 namespace TgBot {
 
 /**
@@ -27,7 +31,7 @@ public:
     /**
      * @brief Optional. Recording duration in seconds
      */
-    int32_t voiceDuration;
+    std::int32_t voiceDuration;
 };
 }
 

--- a/include/tgbot/types/InputMedia.h
+++ b/include/tgbot/types/InputMedia.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INPUTMEDIA_H
 #define TGBOT_INPUTMEDIA_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -15,7 +16,7 @@ class InputMedia {
 public:
     typedef std::shared_ptr<InputMedia> Ptr;
 
-    enum class TYPE : uint8_t {
+    enum class TYPE : std::uint8_t {
         PHOTO,
         VIDEO,
         ANIMATION,
@@ -53,27 +54,27 @@ public:
     /**
      * @brief Optional. Media width
      */
-    int32_t width = 0;
+    std::int32_t width = 0;
 
     /**
      * @brief Optional. Media height
      */
-    int32_t height = 0;
+    std::int32_t height = 0;
 
     /**
      * @brief Optional. Media duration
      */
-    int32_t duration = 0;
+    std::int32_t duration = 0;
 
     /**
      * @brief Optional. Performer of the audio.
      */
-    int32_t performer = 0;
+    std::int32_t performer = 0;
 
     /**
      * @brief Optional. Title of the audio.
      */
-    int32_t title = 0;
+    std::int32_t title = 0;
 
     /**
      * @brief Optional. Pass True, if the uploaded video is suitable for streaming

--- a/include/tgbot/types/Invoice.h
+++ b/include/tgbot/types/Invoice.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_INVOICE_H
 #define TGBOT_INVOICE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -48,7 +49,7 @@ public:
      *
      * https://core.telegram.org/bots/payments/currencies.json
      */
-    int32_t totalAmount;
+    std::int32_t totalAmount;
 };
 }
 

--- a/include/tgbot/types/LabeledPrice.h
+++ b/include/tgbot/types/LabeledPrice.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_LABELEDPRICE_H
 #define TGBOT_LABELEDPRICE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -31,7 +32,7 @@ public:
      *
      * https://core.telegram.org/bots/payments/currencies.json
      */
-    int32_t amount;
+    std::int32_t amount;
 };
 }
 

--- a/include/tgbot/types/Message.h
+++ b/include/tgbot/types/Message.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_MESSAGE_H
 #define TGBOT_CPP_MESSAGE_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>
@@ -39,7 +40,7 @@ public:
     /**
      * @brief Unique message identifier.
      */
-    int32_t messageId;
+    std::int32_t messageId;
 
     /**
      * @brief Optional. Sender, can be empty for messages sent to channels.
@@ -49,7 +50,7 @@ public:
     /**
      * @brief Date the message was sent in Unix time.
      */
-    int32_t date;
+    std::int32_t date;
 
     /**
      * @brief Conversation the message belongs to.
@@ -69,7 +70,7 @@ public:
     /**
      * @brief Optional. For forwarded channel posts, identifier of the original message in the channel
      */
-    int32_t forwardFromMessageId;
+    std::int32_t forwardFromMessageId;
 
     /**
      * @brief Optional. For messages forwarded from channels, signature of the post author if present.
@@ -84,7 +85,7 @@ public:
     /**
      * @brief Optional. For forwarded messages, date the original message was sent in Unix time.
      */
-    int32_t forwardDate;
+    std::int32_t forwardDate;
 
     /**
      * @brief Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
@@ -94,7 +95,7 @@ public:
     /**
      * @brief Optional. Date the message was last edited in Unix time.
      */
-    int32_t editDate;
+    std::int32_t editDate;
 
     /**
      * @brief Optional. Signature of the post author for messages in channels.
@@ -231,12 +232,12 @@ public:
     /**
      * @brief Optional. The group has been migrated to a supergroup with the specified identifier, not exceeding 1e13 by absolute value.
      */
-    int64_t migrateToChatId = 0;
+    std::int64_t migrateToChatId = 0;
 
     /**
      * @brief Optional. The supergroup has been migrated from a group with the specified identifier, not exceeding 1e13 by absolute value
      */
-    int64_t migrateFromChatId = 0;
+    std::int64_t migrateFromChatId = 0;
 
     /**
      * @brief Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.

--- a/include/tgbot/types/MessageEntity.h
+++ b/include/tgbot/types/MessageEntity.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_MESSAGEENTITY_H
 #define TGBOT_MESSAGEENTITY_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include "tgbot/types/User.h"
@@ -26,12 +27,12 @@ public:
     /**
      * @brief Offset in UTF-16 code units to the start of the entity.
      */
-    int32_t offset;
+    std::int32_t offset;
 
     /**
      * @brief Length of the entity in UTF-16 code units
      */
-    int32_t length;
+    std::int32_t length;
 
     /**
      * @brief Optional. For “text_link” only, url that will be opened after user taps on the text

--- a/include/tgbot/types/PhotoSize.h
+++ b/include/tgbot/types/PhotoSize.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_PHOTOSIZE_H
 #define TGBOT_CPP_PHOTOSIZE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -24,17 +25,17 @@ public:
     /**
      * @brief Photo width.
      */
-    int32_t width;
+    std::int32_t width;
 
     /**
      * @brief Photo height.
      */
-    int32_t height;
+    std::int32_t height;
 
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 
 }

--- a/include/tgbot/types/Poll.h
+++ b/include/tgbot/types/Poll.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_POLL_H
 #define TGBOT_POLL_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -19,7 +20,7 @@ namespace TgBot {
         /**
          * @brief Unique poll identifier.
          */
-        int64_t id;
+        std::int64_t id;
 
         /**
          * @brief Poll question, 1-255 characters.

--- a/include/tgbot/types/PollOption.h
+++ b/include/tgbot/types/PollOption.h
@@ -1,9 +1,10 @@
+#ifndef TGBOT_POLLOPTION_H
+#define TGBOT_POLLOPTION_H
+
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
-
-#ifndef TGBOT_POLLOPTION_H
-#define TGBOT_POLLOPTION_H
 
 namespace TgBot {
 
@@ -20,7 +21,7 @@ public:
     /**
      * @brief Number of users that voted for this option.
      */
-    int64_t voter_count;
+    std::int64_t voter_count;
 };
 
 }

--- a/include/tgbot/types/PreCheckoutQuery.h
+++ b/include/tgbot/types/PreCheckoutQuery.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_PRECHECKOUTQUERY_H
 #define TGBOT_PRECHECKOUTQUERY_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <vector>
@@ -46,7 +47,7 @@ public:
      *
      * https://core.telegram.org/bots/payments/currencies.json
      */
-    int32_t totalAmount;
+    std::int32_t totalAmount;
 
     /**
      * @brief Bot specified invoice payload.

--- a/include/tgbot/types/ResponseParameters.h
+++ b/include/tgbot/types/ResponseParameters.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_RESPONSEPARAMETERS_H
 #define TGBOT_RESPONSEPARAMETERS_H
 
+#include <cstdint>
 #include <memory>
 
 namespace TgBot {
@@ -21,12 +22,12 @@ public:
      * difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a
      * signed 64 bit integer or double-precision float type are safe for storing this identifier.
      */
-    int32_t migrateToChatId;
+    std::int32_t migrateToChatId;
 
     /**
      * @brief Optional. In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
      */
-    int32_t retryAfter;
+    std::int32_t retryAfter;
 };
 }
 

--- a/include/tgbot/types/Sticker.h
+++ b/include/tgbot/types/Sticker.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_STICKER_H
 #define TGBOT_CPP_STICKER_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -27,12 +28,12 @@ public:
     /**
      * @brief Optional. Sticker width.
      */
-    int32_t width;
+    std::int32_t width;
 
     /**
      * @brief Optional. Sticker height.
      */
-    int32_t height;
+    std::int32_t height;
 
     /**
  * @brief True, if the sticker is animated.
@@ -62,7 +63,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 
 }

--- a/include/tgbot/types/SuccessfulPayment.h
+++ b/include/tgbot/types/SuccessfulPayment.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_SUCCESSFULPAYMENT_H
 #define TGBOT_SUCCESSFULPAYMENT_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <vector>
@@ -35,7 +36,7 @@ public:
      *
      * https://core.telegram.org/bots/payments/currencies.json
      */
-    int32_t totalAmount;
+    std::int32_t totalAmount;
 
     /**
      * @brief Bot specified invoice payload.

--- a/include/tgbot/types/Update.h
+++ b/include/tgbot/types/Update.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_UPDATE_H
 #define TGBOT_CPP_UPDATE_H
 
+#include <cstdint>
 #include <memory>
 
 #include "tgbot/types/Message.h"
@@ -25,7 +26,7 @@ public:
     /**
      * @brief The update‘s unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you’re using Webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order.
      */
-    int32_t updateId;
+    std::int32_t updateId;
 
     /**
      * @brief Optional. New incoming message of any kind — text, photo, sticker, etc.

--- a/include/tgbot/types/User.h
+++ b/include/tgbot/types/User.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_USER_H
 #define TGBOT_CPP_USER_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -19,7 +20,7 @@ public:
     /**
      * @brief Unique identifier for this user or bot.
      */
-    int32_t id;
+    std::int32_t id;
 
     /**
      * @brief True, if this user is a bot

--- a/include/tgbot/types/UserProfilePhotos.h
+++ b/include/tgbot/types/UserProfilePhotos.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_USERPROFILEPHOTOS_H
 #define TGBOT_CPP_USERPROFILEPHOTOS_H
 
+#include <cstdint>
 #include <vector>
 #include <memory>
 
@@ -21,7 +22,7 @@ public:
     /**
      * @brief Total number of profile pictures the target user has.
      */
-    int32_t totalCount;
+    std::int32_t totalCount;
 
     /**
      * @brief Requested profile pictures (in up to 4 sizes each).

--- a/include/tgbot/types/Video.h
+++ b/include/tgbot/types/Video.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_VIDEO_H
 #define TGBOT_CPP_VIDEO_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -26,17 +27,17 @@ public:
     /**
      * @brief Video width as defined by sender.
      */
-    int32_t width;
+    std::int32_t width;
 
     /**
      * @brief Video height as defined by sender.
      */
-    int32_t height;
+    std::int32_t height;
 
     /**
      * @brief Duration of the video in seconds as defined by sender.
      */
-    int32_t duration;
+    std::int32_t duration;
 
     /**
      * @brief Optional. Video thumbnail.
@@ -51,7 +52,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 
 }

--- a/include/tgbot/types/VideoNote.h
+++ b/include/tgbot/types/VideoNote.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_CPP_VIDEONOTE_H
 #define TGBOT_CPP_VIDEONOTE_H
 
+#include <cstdint>
 #include <string>
 #include <memory>
 
@@ -26,12 +27,12 @@ public:
     /**
      * @brief Video width and height as defined by sender.
      */
-    int32_t length;
+    std::int32_t length;
 
     /**
      * @brief Duration of the video in seconds as defined by sender.
      */
-    int32_t duration;
+    std::int32_t duration;
 
     /**
      * @brief Optional. Video thumbnail.
@@ -41,7 +42,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 
 }

--- a/include/tgbot/types/Voice.h
+++ b/include/tgbot/types/Voice.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_VOICE_H
 #define TGBOT_VOICE_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -23,7 +24,7 @@ public:
     /**
      * @brief Duration of the audio in seconds as defined by sender.
      */
-    int32_t duration;
+    std::int32_t duration;
 
     /**
      * @brief Optional. MIME type of the file as defined by sender;
@@ -33,7 +34,7 @@ public:
     /**
      * @brief Optional. File size.
      */
-    int32_t fileSize;
+    std::int32_t fileSize;
 };
 }
 

--- a/include/tgbot/types/WebhookInfo.h
+++ b/include/tgbot/types/WebhookInfo.h
@@ -1,6 +1,7 @@
 #ifndef TGBOT_WEBHOOKINFO_H
 #define TGBOT_WEBHOOKINFO_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>
@@ -29,12 +30,12 @@ public:
     /**
      * @brief Number of updates awaiting delivery
      */
-    int32_t pendingUpdateCount;
+    std::int32_t pendingUpdateCount;
 
     /**
      * @brief Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
      */
-    int32_t lastErrorDate;
+    std::int32_t lastErrorDate;
 
     /**
      * @brief Optional. Error message in human - readable format for the most recent error that happened when trying to deliver an update via webhook
@@ -44,7 +45,7 @@ public:
     /**
      * @brief Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
      */
-    int32_t maxConnections;
+    std::int32_t maxConnections;
 
     /**
      * @brief Optional. A list of update types the bot is subscribed to. Defaults to all update types

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1,5 +1,6 @@
 #include "tgbot/Api.h"
 
+#include <cstdint>
 #include <utility>
 
 #include "tgbot/TgTypeParser.h"
@@ -18,7 +19,7 @@ User::Ptr Api::getMe() const {
     return _tgTypeParser.parseJsonAndGetUser(sendRequest("getMe"));
 }
 
-Message::Ptr Api::sendMessage(int64_t chatId, const string& text, bool disableWebPagePreview, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendMessage(std::int64_t chatId, const string& text, bool disableWebPagePreview, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("chat_id", chatId);
@@ -41,7 +42,7 @@ Message::Ptr Api::sendMessage(int64_t chatId, const string& text, bool disableWe
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendMessage", args));
 }
 
-Message::Ptr Api::forwardMessage(int64_t chatId, int64_t fromChatId, int32_t messageId, bool disableNotification) const {
+Message::Ptr Api::forwardMessage(std::int64_t chatId, std::int64_t fromChatId, std::int32_t messageId, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     args.emplace_back("chat_id", chatId);
@@ -53,7 +54,7 @@ Message::Ptr Api::forwardMessage(int64_t chatId, int64_t fromChatId, int32_t mes
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("forwardMessage", args));
 }
 
-Message::Ptr Api::sendPhoto(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> photo, const string& caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendPhoto(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> photo, const string& caption, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("chat_id", chatId);
@@ -81,7 +82,7 @@ Message::Ptr Api::sendPhoto(int64_t chatId, const boost::variant<InputFile::Ptr,
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendPhoto", args));
 }
 
-Message::Ptr Api::sendAudio(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> audio, const string &caption, int32_t duration, const string& performer, const string& title, const boost::variant<InputFile::Ptr, std::string> thumb, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendAudio(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> audio, const string &caption, std::int32_t duration, const string& performer, const string& title, const boost::variant<InputFile::Ptr, std::string> thumb, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(11);
     args.emplace_back("chat_id", chatId);
@@ -127,7 +128,7 @@ Message::Ptr Api::sendAudio(int64_t chatId, const boost::variant<InputFile::Ptr,
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendAudio", args));
 }
 
-Message::Ptr Api::sendDocument(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> document, const boost::variant<InputFile::Ptr, std::string> thumb, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendDocument(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> document, const boost::variant<InputFile::Ptr, std::string> thumb, const string &caption, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(8);
     args.emplace_back("chat_id", chatId);
@@ -164,13 +165,13 @@ Message::Ptr Api::sendDocument(int64_t chatId, const boost::variant<InputFile::P
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendDocument", args));
 }
 
-Message::Ptr Api::sendInvoice(int64_t chatId, const std::string& title, const std::string& description, const std::string& payload,
+Message::Ptr Api::sendInvoice(std::int64_t chatId, const std::string& title, const std::string& description, const std::string& payload,
                              const std::string& providerToken, const std::string& startParameter, const std::string& currency, const std::vector<LabeledPrice::Ptr>& prices,
-                             const std::string& providerData, const std::string& photoUrl, int32_t photoSize,
-                             int32_t photoWidth, int32_t photoHeight, bool needName,
+                             const std::string& providerData, const std::string& photoUrl, std::int32_t photoSize,
+                             std::int32_t photoWidth, std::int32_t photoHeight, bool needName,
                              bool needPhoneNumber, bool needEmail, bool needShippingAddress,
                              bool sendPhoneNumberToProvider, bool sendEmailToProvider, bool isFlexible,
-                             int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+                             std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(23);
     args.emplace_back("chat_id", chatId);
@@ -255,7 +256,7 @@ bool Api::answerPreCheckoutQuery(const std::string& preCheckoutQueryId, bool ok,
 }
 
 
-Message::Ptr Api::sendSticker(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> sticker, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendSticker(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> sticker, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(5);
     args.emplace_back("chat_id", chatId);
@@ -284,7 +285,7 @@ StickerSet::Ptr Api::getStickerSet(const string& name) const {
     return _tgTypeParser.parseJsonAndGetStickerSet(sendRequest("getStickerSet", args));
 }
 
-File::Ptr Api::uploadStickerFile(int32_t userId, const InputFile::Ptr pngSticker) const {
+File::Ptr Api::uploadStickerFile(std::int32_t userId, const InputFile::Ptr pngSticker) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("user_id", userId);
@@ -292,7 +293,7 @@ File::Ptr Api::uploadStickerFile(int32_t userId, const InputFile::Ptr pngSticker
     return _tgTypeParser.parseJsonAndGetFile(sendRequest("uploadStickerFile", args));
 }
 
-bool Api::createNewStickerSet(int32_t userId, const string& name, const string& title, const boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, bool containsMasks, MaskPosition::Ptr maskPosition) const {
+bool Api::createNewStickerSet(std::int32_t userId, const string& name, const string& title, const boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, bool containsMasks, MaskPosition::Ptr maskPosition) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);
@@ -314,7 +315,7 @@ bool Api::createNewStickerSet(int32_t userId, const string& name, const string& 
     return sendRequest("createNewStickerSet", args).get<bool>("", false);
 }
 
-bool Api::addStickerToSet(int32_t userId, const string& name, const boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, MaskPosition::Ptr maskPosition) const {
+bool Api::addStickerToSet(std::int32_t userId, const string& name, const boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, MaskPosition::Ptr maskPosition) const {
     vector<HttpReqArg> args;
     args.reserve(6);
     args.emplace_back("user_id", userId);
@@ -332,7 +333,7 @@ bool Api::addStickerToSet(int32_t userId, const string& name, const boost::varia
     return sendRequest("addStickerToSet", args).get<bool>("", false);
 }
 
-bool Api::setStickerPositionInSet(const string& sticker, uint32_t position) const {
+bool Api::setStickerPositionInSet(const string& sticker, std::uint32_t position) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("sticker", sticker);
@@ -347,7 +348,7 @@ bool Api::deleteStickerFromSet(const string& sticker) const {
     return sendRequest("deleteStickerFromSet", args).get<bool>("", false);
 }
 
-Message::Ptr Api::sendVideo(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> video, bool supportsStreaming, int32_t duration, int32_t width, int32_t height, const boost::variant<InputFile::Ptr, std::string> thumb, const string &caption, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendVideo(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> video, bool supportsStreaming, std::int32_t duration, std::int32_t width, std::int32_t height, const boost::variant<InputFile::Ptr, std::string> thumb, const string &caption, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(12);
     args.emplace_back("chat_id", chatId);
@@ -396,7 +397,7 @@ Message::Ptr Api::sendVideo(int64_t chatId, const boost::variant<InputFile::Ptr,
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendVideo", args));
 }
 
-Message::Ptr Api::sendAnimation(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> animation, int32_t duration, int32_t width, int32_t height, const boost::variant<InputFile::Ptr, std::string> thumb, const string& caption, int32_t replyToMessageId, GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendAnimation(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> animation, std::int32_t duration, std::int32_t width, std::int32_t height, const boost::variant<InputFile::Ptr, std::string> thumb, const string& caption, std::int32_t replyToMessageId, GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(11);
     args.emplace_back("chat_id", chatId);
@@ -442,7 +443,7 @@ Message::Ptr Api::sendAnimation(int64_t chatId, const boost::variant<InputFile::
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendAnimation", args));
 }
 
-Message::Ptr Api::sendVideoNote(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> videoNote, int64_t replyToMessageId, bool disableNotification, int32_t duration, int32_t length, const boost::variant<InputFile::Ptr, std::string> thumb, const GenericReply::Ptr replyMarkup) const {
+Message::Ptr Api::sendVideoNote(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> videoNote, std::int64_t replyToMessageId, bool disableNotification, std::int32_t duration, std::int32_t length, const boost::variant<InputFile::Ptr, std::string> thumb, const GenericReply::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(8);
     args.emplace_back("chat_id", chatId);
@@ -479,7 +480,7 @@ Message::Ptr Api::sendVideoNote(int64_t chatId, const boost::variant<InputFile::
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendVideoNote", args));
 }
 
-vector<Message::Ptr> Api::sendMediaGroup(int64_t chatId, const vector<InputMedia::Ptr>& media, bool disableNotification, int32_t replyToMessageId) const {
+vector<Message::Ptr> Api::sendMediaGroup(std::int64_t chatId, const vector<InputMedia::Ptr>& media, bool disableNotification, std::int32_t replyToMessageId) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     args.emplace_back("chat_id", chatId);
@@ -490,7 +491,7 @@ vector<Message::Ptr> Api::sendMediaGroup(int64_t chatId, const vector<InputMedia
     return _tgTypeParser.parseJsonAndGetArray<Message>(&TgTypeParser::parseJsonAndGetMessage, sendRequest("sendMediaGroup", args));
 }
 
-Message::Ptr Api::sendVoice(int64_t chatId, const boost::variant<InputFile::Ptr, std::string> voice, const string &caption, int duration, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
+Message::Ptr Api::sendVoice(std::int64_t chatId, const boost::variant<InputFile::Ptr, std::string> voice, const string &caption, int duration, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, const string& parseMode, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(8);
     args.emplace_back("chat_id", chatId);
@@ -521,7 +522,7 @@ Message::Ptr Api::sendVoice(int64_t chatId, const boost::variant<InputFile::Ptr,
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendVoice", args));
 }
 
-Message::Ptr Api::sendGame(int64_t chatId, const std::string& gameShortName, int32_t replyToMessageId, const InlineKeyboardMarkup::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendGame(std::int64_t chatId, const std::string& gameShortName, std::int32_t replyToMessageId, const InlineKeyboardMarkup::Ptr replyMarkup, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(5);
     args.emplace_back("chat_id", chatId);
@@ -538,7 +539,7 @@ Message::Ptr Api::sendGame(int64_t chatId, const std::string& gameShortName, int
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendGame", args));
 }
 
-Message::Ptr Api::sendLocation(int64_t chatId, float latitude, float longitude, uint32_t livePeriod, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
+Message::Ptr Api::sendLocation(std::int64_t chatId, float latitude, float longitude, std::uint32_t livePeriod, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("chat_id", chatId);
@@ -559,7 +560,7 @@ Message::Ptr Api::sendLocation(int64_t chatId, float latitude, float longitude, 
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendLocation", args));
 }
 
-Message::Ptr Api::editMessageLiveLocation(float latitude, float longitude, int64_t chatId, int32_t messageId, int32_t inlineMessageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
+Message::Ptr Api::editMessageLiveLocation(float latitude, float longitude, std::int64_t chatId, std::int32_t messageId, std::int32_t inlineMessageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(6);
     args.emplace_back("latitude", latitude);
@@ -579,7 +580,7 @@ Message::Ptr Api::editMessageLiveLocation(float latitude, float longitude, int64
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("editMessageLiveLocation", args));
 }
 
-Message::Ptr Api::stopMessageLiveLocation(int64_t chatId, int32_t messageId, int32_t inlineMessageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
+Message::Ptr Api::stopMessageLiveLocation(std::int64_t chatId, std::int32_t messageId, std::int32_t inlineMessageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     if (chatId) {
@@ -597,7 +598,7 @@ Message::Ptr Api::stopMessageLiveLocation(int64_t chatId, int32_t messageId, int
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("editMessageLiveLocation", args));
 }
 
-bool Api::setChatStickerSet(int64_t chatId, const string& stickerSetName) const {
+bool Api::setChatStickerSet(std::int64_t chatId, const string& stickerSetName) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -605,14 +606,14 @@ bool Api::setChatStickerSet(int64_t chatId, const string& stickerSetName) const 
     return sendRequest("setChatStickerSet", args).get<bool>("", false);
 }
 
-bool Api::deleteChatStickerSet(int64_t chatId) const {
+bool Api::deleteChatStickerSet(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("deleteChatStickerSet", args).get<bool>("", false);
 }
 
-Message::Ptr Api::sendVenue(int64_t chatId, float latitude, float longitude, const string& title, const string& address, const string& foursquareId, const string& foursquareType, bool disableNotification, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup) const {
+Message::Ptr Api::sendVenue(std::int64_t chatId, float latitude, float longitude, const string& title, const string& address, const string& foursquareId, const string& foursquareType, bool disableNotification, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(10);
     args.emplace_back("chat_id", chatId);
@@ -638,7 +639,7 @@ Message::Ptr Api::sendVenue(int64_t chatId, float latitude, float longitude, con
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendVenue", args));
 }
 
-Message::Ptr Api::sendContact(int64_t chatId, const string& phoneNumber, const string& firstName, const string& lastName, const string& vcard, bool disableNotification, int32_t replyToMessageId, const GenericReply::Ptr replyMarkup) const {
+Message::Ptr Api::sendContact(std::int64_t chatId, const string& phoneNumber, const string& firstName, const string& lastName, const string& vcard, bool disableNotification, std::int32_t replyToMessageId, const GenericReply::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(8);
     args.emplace_back("chat_id", chatId);
@@ -662,7 +663,7 @@ Message::Ptr Api::sendContact(int64_t chatId, const string& phoneNumber, const s
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendContact", args));
 }
 
-void Api::sendChatAction(int64_t chatId, const string& action) const {
+void Api::sendChatAction(std::int64_t chatId, const string& action) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -670,7 +671,7 @@ void Api::sendChatAction(int64_t chatId, const string& action) const {
     sendRequest("sendChatAction", args);
 }
 
-UserProfilePhotos::Ptr Api::getUserProfilePhotos(int32_t userId, int32_t offset, int32_t limit) const {
+UserProfilePhotos::Ptr Api::getUserProfilePhotos(std::int32_t userId, std::int32_t offset, std::int32_t limit) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("user_id", userId);
@@ -689,35 +690,35 @@ File::Ptr Api::getFile(const string &fileId) const {
     return _tgTypeParser.parseJsonAndGetFile(sendRequest("getFile", args));
 }
 
-bool Api::leaveChat(int64_t chatId) const {
+bool Api::leaveChat(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("leaveChat", args).get<bool>("", false);
 }
 
-Chat::Ptr Api::getChat(int64_t chatId) const {
+Chat::Ptr Api::getChat(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return _tgTypeParser.parseJsonAndGetChat(sendRequest("getChat", args));
 }
 
-vector<ChatMember::Ptr> Api::getChatAdministrators(int64_t chatId) const {
+vector<ChatMember::Ptr> Api::getChatAdministrators(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return _tgTypeParser.parseJsonAndGetArray<ChatMember>(&TgTypeParser::parseJsonAndGetChatMember, sendRequest("getChatAdministrators", args));
 }
 
-int32_t Api::getChatMembersCount(int64_t chatId) const {
+int32_t Api::getChatMembersCount(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("getChatMembersCount", args).get<int32_t>("", 0);
 }
 
-bool Api::answerCallbackQuery(const string & callbackQueryId, const string & text, bool showAlert, const string &url, int32_t cacheTime) const {
+bool Api::answerCallbackQuery(const string & callbackQueryId, const string & text, bool showAlert, const string &url, std::int32_t cacheTime) const {
     vector<HttpReqArg> args;
     args.reserve(5);
     args.emplace_back("callback_query_id", callbackQueryId);
@@ -736,7 +737,7 @@ bool Api::answerCallbackQuery(const string & callbackQueryId, const string & tex
     return sendRequest("answerCallbackQuery", args).get<bool>("", false);
 }
 
-Message::Ptr Api::editMessageText(const string& text, int64_t chatId, int32_t messageId, const string& inlineMessageId,
+Message::Ptr Api::editMessageText(const string& text, std::int64_t chatId, std::int32_t messageId, const string& inlineMessageId,
     const string& parseMode, bool disableWebPagePreview, const GenericReply::Ptr replyMarkup) const {
 
     vector<HttpReqArg> args;
@@ -768,7 +769,7 @@ Message::Ptr Api::editMessageText(const string& text, int64_t chatId, int32_t me
     }
 }
 
-Message::Ptr Api::editMessageCaption(int64_t chatId, int32_t messageId, const string& caption,
+Message::Ptr Api::editMessageCaption(std::int64_t chatId, std::int32_t messageId, const string& caption,
                                      const string& inlineMessageId, const GenericReply::Ptr replyMarkup) const {
 
     vector<HttpReqArg> args;
@@ -796,7 +797,7 @@ Message::Ptr Api::editMessageCaption(int64_t chatId, int32_t messageId, const st
     }
 }
 
-Message::Ptr Api::editMessageReplyMarkup(int64_t chatId, int32_t messageId, const string& inlineMessageId,
+Message::Ptr Api::editMessageReplyMarkup(std::int64_t chatId, std::int32_t messageId, const string& inlineMessageId,
                                          const GenericReply::Ptr replyMarkup) const {
 
     vector<HttpReqArg> args;
@@ -821,7 +822,7 @@ Message::Ptr Api::editMessageReplyMarkup(int64_t chatId, int32_t messageId, cons
     }
 }
 
-Message::Ptr Api::editMessageMedia(InputMedia::Ptr media, int64_t chatId, int32_t messageId, const std::string& inlineMessageId,
+Message::Ptr Api::editMessageMedia(InputMedia::Ptr media, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId,
                                   GenericReply::Ptr replyMarkup) const {
 
     vector<HttpReqArg> args;
@@ -847,7 +848,7 @@ Message::Ptr Api::editMessageMedia(InputMedia::Ptr media, int64_t chatId, int32_
     }
 }
 
-ChatMember::Ptr Api::getChatMember(int64_t chatId, int32_t userId) const {
+ChatMember::Ptr Api::getChatMember(std::int64_t chatId, std::int32_t userId) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -855,7 +856,7 @@ ChatMember::Ptr Api::getChatMember(int64_t chatId, int32_t userId) const {
     return _tgTypeParser.parseJsonAndGetChatMember(sendRequest("getChatMember", args));
 }
 
-vector<Update::Ptr> Api::getUpdates(int32_t offset, int32_t limit, int32_t timeout, const StringArrayPtr &allowedUpdates) const {
+vector<Update::Ptr> Api::getUpdates(std::int32_t offset, std::int32_t limit, std::int32_t timeout, const StringArrayPtr &allowedUpdates) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     if (offset) {
@@ -876,7 +877,7 @@ vector<Update::Ptr> Api::getUpdates(int32_t offset, int32_t limit, int32_t timeo
     return _tgTypeParser.parseJsonAndGetArray<Update>(&TgTypeParser::parseJsonAndGetUpdate, sendRequest("getUpdates", args));
 }
 
-void Api::setWebhook(const string& url, const InputFile::Ptr certificate, int32_t maxConnection, const StringArrayPtr &allowedUpdates) const {
+void Api::setWebhook(const string& url, const InputFile::Ptr certificate, std::int32_t maxConnection, const StringArrayPtr &allowedUpdates) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     if (!url.empty()) {
@@ -918,7 +919,7 @@ WebhookInfo::Ptr Api::getWebhookInfo() const {
 }
 
 bool Api::answerInlineQuery(const string& inlineQueryId, const std::vector<InlineQueryResult::Ptr>& results,
-                            int32_t cacheTime, bool isPersonal, const string& nextOffset, const string& switchPmText, const string& switchPmParameter) const {
+                            std::int32_t cacheTime, bool isPersonal, const string& nextOffset, const string& switchPmText, const string& switchPmParameter) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("inline_query_id", inlineQueryId);
@@ -942,7 +943,7 @@ bool Api::answerInlineQuery(const string& inlineQueryId, const std::vector<Inlin
     return sendRequest("answerInlineQuery", args).get<bool>("", false);
 }
 
-bool Api::kickChatMember(int64_t chatId, int32_t userId, uint64_t untilDate) const {
+bool Api::kickChatMember(std::int64_t chatId, std::int32_t userId, std::uint64_t untilDate) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("chat_id", chatId);
@@ -953,15 +954,15 @@ bool Api::kickChatMember(int64_t chatId, int32_t userId, uint64_t untilDate) con
     return sendRequest("kickChatMember", args).get<bool>("", false);
 }
 
-bool Api::unbanChatMember(int64_t chatId, int32_t userId) const {
+bool Api::unbanChatMember(std::int64_t chatId, std::int32_t userId) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
     args.emplace_back("user_id", userId);
     return sendRequest("unbanChatMember", args).get<bool>("", false);
 }
-bool Api::restrictChatMember(int64_t chatId, int32_t userId, TgBot::ChatPermissions::Ptr permissions,
-                             uint64_t untilDate) const {
+bool Api::restrictChatMember(std::int64_t chatId, std::int32_t userId, TgBot::ChatPermissions::Ptr permissions,
+                             std::uint64_t untilDate) const {
     vector<HttpReqArg> args;
     args.reserve(4);
     args.emplace_back("chat_id", chatId);
@@ -974,7 +975,7 @@ bool Api::restrictChatMember(int64_t chatId, int32_t userId, TgBot::ChatPermissi
     return sendRequest("restrictChatMember", args).get<bool>("", false);
 }
 
-bool Api::promoteChatMember(int64_t chatId, int32_t userId, bool canChangeInfo, bool canPostMessages,
+bool Api::promoteChatMember(std::int64_t chatId, std::int32_t userId, bool canChangeInfo, bool canPostMessages,
                             bool canEditMessages, bool canDeleteMessages, bool canInviteUsers, bool canPinMessages, bool canPromoteMembers) const {
     vector<HttpReqArg> args;
     args.reserve(9);
@@ -1004,7 +1005,7 @@ bool Api::promoteChatMember(int64_t chatId, int32_t userId, bool canChangeInfo, 
     return sendRequest("promoteChatMember", args).get<bool>("", false);
 }
 
-bool Api::setChatPermissions(int64_t chatId, ChatPermissions::Ptr permissions) const{
+bool Api::setChatPermissions(std::int64_t chatId, ChatPermissions::Ptr permissions) const{
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -1012,14 +1013,14 @@ bool Api::setChatPermissions(int64_t chatId, ChatPermissions::Ptr permissions) c
     return sendRequest("setChatPermissions", args).get<bool>("", false);
 }
 
-string Api::exportChatInviteLink(int64_t chatId) const {
+string Api::exportChatInviteLink(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("exportChatInviteLink", args).get("", "");
 }
 
-bool Api::setChatPhoto(int64_t chatId, const InputFile::Ptr photo) const {
+bool Api::setChatPhoto(std::int64_t chatId, const InputFile::Ptr photo) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -1027,14 +1028,14 @@ bool Api::setChatPhoto(int64_t chatId, const InputFile::Ptr photo) const {
     return sendRequest("setChatPhoto", args).get<bool>("", false);
 }
 
-bool Api::deleteChatPhoto(int64_t chatId) const {
+bool Api::deleteChatPhoto(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("deleteChatPhoto", args).get<bool>("", false);
 }
 
-bool Api::setChatTitle(int64_t chatId, const string& title) const {
+bool Api::setChatTitle(std::int64_t chatId, const string& title) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -1042,7 +1043,7 @@ bool Api::setChatTitle(int64_t chatId, const string& title) const {
     return sendRequest("setChatTitle", args).get<bool>("", false);
 }
 
-bool Api::setChatDescription(int64_t chatId, const string& description) const {
+bool Api::setChatDescription(std::int64_t chatId, const string& description) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -1050,7 +1051,7 @@ bool Api::setChatDescription(int64_t chatId, const string& description) const {
     return sendRequest("setChatDescription", args).get<bool>("", false);
 }
 
-bool Api::pinChatMessage(int64_t chatId, int32_t messageId, bool disableNotification) const {
+bool Api::pinChatMessage(std::int64_t chatId, std::int32_t messageId, bool disableNotification) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("chat_id", chatId);
@@ -1061,14 +1062,14 @@ bool Api::pinChatMessage(int64_t chatId, int32_t messageId, bool disableNotifica
     return sendRequest("pinChatMessage", args).get<bool>("", false);
 }
 
-bool Api::unpinChatMessage(int64_t chatId) const {
+bool Api::unpinChatMessage(std::int64_t chatId) const {
     vector<HttpReqArg> args;
     args.reserve(1);
     args.emplace_back("chat_id", chatId);
     return sendRequest("unpinChatMessage", args).get<bool>("", false);
 }
 
-Message::Ptr Api::setGameScore(int32_t userId, int32_t score, bool force, bool disableEditMessage, int64_t chatId, int32_t messageId, const std::string& inlineMessageId) const {
+Message::Ptr Api::setGameScore(std::int32_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);
@@ -1091,7 +1092,7 @@ Message::Ptr Api::setGameScore(int32_t userId, int32_t score, bool force, bool d
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("setGameScore", args));
 }
 
-vector<GameHighScore::Ptr> Api::getGameHighScores(int32_t userId, int32_t score, bool force, bool disableEditMessage, int64_t chatId, int32_t messageId, const std::string& inlineMessageId) const {
+vector<GameHighScore::Ptr> Api::getGameHighScores(std::int32_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);
@@ -1114,11 +1115,11 @@ vector<GameHighScore::Ptr> Api::getGameHighScores(int32_t userId, int32_t score,
     return _tgTypeParser.parseJsonAndGetArray<GameHighScore>(&TgTypeParser::parseJsonAndGetGameHighScore, sendRequest("getGameHighScores", args));
 }
 
-void Api::deleteMessage(int64_t chatId, int32_t messageId) const {
+void Api::deleteMessage(std::int64_t chatId, std::int32_t messageId) const {
     sendRequest("deleteMessage", { HttpReqArg("chat_id", chatId), HttpReqArg("message_id", messageId) });
 }
 
-Message::Ptr Api::sendPoll(int64_t chat_id, std::string question, std::vector<std::string> options, bool disable_notification, int32_t reply_to_message_id,GenericReply::Ptr reply_markup) const {
+Message::Ptr Api::sendPoll(std::int64_t chat_id, std::string question, std::vector<std::string> options, bool disable_notification, std::int32_t reply_to_message_id,GenericReply::Ptr reply_markup) const {
     vector<HttpReqArg> args;
     args.reserve(6);
     args.emplace_back("chat_id", chat_id);
@@ -1144,7 +1145,7 @@ Message::Ptr Api::sendPoll(int64_t chat_id, std::string question, std::vector<st
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("sendPoll", args));
 }
 
-Poll::Ptr Api::stopPoll(int64_t chatId, int64_t messageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
+Poll::Ptr Api::stopPoll(std::int64_t chatId, std::int64_t messageId, const InlineKeyboardMarkup::Ptr replyMarkup) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("chat_id", chatId);

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -1,5 +1,7 @@
 #include "tgbot/EventHandler.h"
+
 #include <algorithm>
+#include <cstddef>
 
 using namespace std;
 
@@ -24,9 +26,9 @@ void EventHandler::handleMessage(Message::Ptr message) const {
     _broadcaster.broadcastAnyMessage(message);
 
     if (StringTools::startsWith(message->text, "/")) {
-        size_t splitPosition;
-        size_t spacePosition = message->text.find(' ');
-        size_t atSymbolPosition = message->text.find('@');
+        std::size_t splitPosition;
+        std::size_t spacePosition = message->text.find(' ');
+        std::size_t atSymbolPosition = message->text.find('@');
         if (spacePosition == string::npos) {
             if (atSymbolPosition == string::npos) {
                 splitPosition = message->text.size();

--- a/src/net/BoostHttpOnlySslClient.cpp
+++ b/src/net/BoostHttpOnlySslClient.cpp
@@ -1,5 +1,7 @@
 #include "tgbot/net/BoostHttpOnlySslClient.h"
 
+#include <cstddef>
+
 #include <boost/asio/ssl.hpp>
 
 using namespace std;
@@ -59,7 +61,7 @@ string BoostHttpOnlySslClient::makeRequest(const Url& url, const vector<HttpReqA
 
     boost::system::error_code error;
     while (!error) {
-        size_t bytes = read(socket, buffer(buff), error);
+        std::size_t bytes = read(socket, buffer(buff), error);
         response += string(buff, bytes);
     }
 

--- a/src/net/CurlHttpClient.cpp
+++ b/src/net/CurlHttpClient.cpp
@@ -2,6 +2,8 @@
 
 #include "tgbot/net/CurlHttpClient.h"
 
+#include <cstddef>
+
 #include <boost/asio/ssl.hpp>
 
 namespace TgBot {
@@ -14,7 +16,7 @@ CurlHttpClient::~CurlHttpClient() {
     curl_easy_cleanup(curlSettings);
 }
 
-static size_t curlWriteString(char* ptr, size_t size, size_t nmemb, void* userdata) {
+static std::size_t curlWriteString(char* ptr, std::size_t size, std::size_t nmemb, void* userdata) {
     static_cast<std::string *>(userdata)->append(ptr, size * nmemb);
     return size * nmemb;
 };

--- a/src/net/HttpParser.cpp
+++ b/src/net/HttpParser.cpp
@@ -1,5 +1,7 @@
 #include "tgbot/net/HttpParser.h"
 
+#include <cstdint>
+
 #include <boost/algorithm/string.hpp>
 
 #include "tgbot/tools/StringTools.h"
@@ -78,7 +80,7 @@ string HttpParser::generateMultipartFormData(const vector<HttpReqArg>& args, con
 
 string HttpParser::generateMultipartBoundary(const vector<HttpReqArg>& args) const {
     string result;
-    srand((uint32_t) time(nullptr));
+    srand((std::uint32_t) time(nullptr));
     for (const HttpReqArg& item : args) {
         if (item.isFile) {
             while (result.empty() || item.value.find(result) != string::npos) {

--- a/src/net/HttpParser.cpp
+++ b/src/net/HttpParser.cpp
@@ -1,5 +1,6 @@
 #include "tgbot/net/HttpParser.h"
 
+#include <cstddef>
 #include <cstdint>
 
 #include <boost/algorithm/string.hpp>
@@ -133,10 +134,10 @@ string HttpParser::generateResponse(const string& data, const string& mimeType, 
 unordered_map<string, string> HttpParser::parseHeader(const string& data, bool isRequest) const {
     unordered_map<string, string> headers;
 
-    size_t lineStart = 0;
-    size_t lineEnd = 0;
-    size_t lineSepPos = 0;
-    size_t lastLineEnd = string::npos;
+    std::size_t lineStart = 0;
+    std::size_t lineEnd = 0;
+    std::size_t lineSepPos = 0;
+    std::size_t lastLineEnd = string::npos;
     while (lastLineEnd != lineEnd) {
         lastLineEnd = lineEnd;
         bool isFirstLine = lineEnd == 0;
@@ -167,7 +168,7 @@ unordered_map<string, string> HttpParser::parseHeader(const string& data, bool i
 }
 
 string HttpParser::extractBody(const string& data) const {
-    size_t headerEnd = data.find("\r\n\r\n");
+    std::size_t headerEnd = data.find("\r\n\r\n");
     if (headerEnd == string::npos) {
         return data;
     }

--- a/src/net/TgLongPoll.cpp
+++ b/src/net/TgLongPoll.cpp
@@ -1,12 +1,14 @@
 #include "tgbot/net/TgLongPoll.h"
 
+#include <cstdint>
+
 namespace TgBot {
 
-TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates)
+TgLongPoll::TgLongPoll(const Api* api, const EventHandler* eventHandler, std::int32_t limit, std::int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates)
     : _api(api), _eventHandler(eventHandler), _limit(limit), _timeout(timeout), _allowupdates(allowupdates) {
 }
 
-TgLongPoll::TgLongPoll(const Bot& bot, int32_t limit, int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates) :
+TgLongPoll::TgLongPoll(const Bot& bot, std::int32_t limit, std::int32_t timeout, const std::shared_ptr<std::vector<std::string>>& allowupdates) :
     TgLongPoll(&bot.getApi(), &bot.getEventHandler(), limit, timeout, allowupdates) {
 }
 

--- a/src/net/Url.cpp
+++ b/src/net/Url.cpp
@@ -1,5 +1,7 @@
 #include "tgbot/net/Url.h"
 
+#include <cstddef>
+
 #include "tgbot/tools/StringTools.h"
 
 using namespace std;
@@ -12,7 +14,7 @@ Url::Url(const string& url) {
     bool isPathParsed = false;
     bool isQueryParsed = false;
 
-    for (size_t i = 0, count = url.length(); i < count; ++i) {
+    for (std::size_t i = 0, count = url.length(); i < count; ++i) {
         char c = url[i];
 
         if (!isProtocolParsed) {

--- a/src/tools/StringTools.cpp
+++ b/src/tools/StringTools.cpp
@@ -54,11 +54,11 @@ void split(const string& str, char delimiter, vector<string>& dest) {
     }
 }
 
-string generateRandomString(size_t length) {
+string generateRandomString(std::size_t length) {
     static const string chars("qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890-=[]\\;',./!@#$%^&*()_+{}|:\"<>?`~");
-    static const size_t charsLen = chars.length();
+    static const std::size_t charsLen = chars.length();
     string result;
-    for (size_t i = 0; i < length; ++i) {
+    for (std::size_t i = 0; i < length; ++i) {
         result += chars[rand() % charsLen];
     }
     return result;
@@ -81,7 +81,7 @@ string urlEncode(const string& value, const std::string& additionalLegitChars) {
 
 string urlDecode(const string& value) {
     string result;
-    for (size_t i = 0, count = value.length(); i < count; ++i) {
+    for (std::size_t i = 0, count = value.length(); i < count; ++i) {
         const char c = value[i];
         if (c == '%') {
             int t = 0;

--- a/test/utils.h
+++ b/test/utils.h
@@ -24,7 +24,7 @@ inline std::string diff(const T& test, const T& expected, std::string (*toString
     typename T::const_iterator end2 = expected.end();
     bool r1, r2;
     std::string s1, s2;
-    size_t i = 0;
+    std::size_t i = 0;
     do {
         r1 = iter1 != end1;
         r2 = iter2 != end2;


### PR DESCRIPTION
- C++ standard doesn't guarantee that C-types without std namespace are available in global namespace. So the proper solution (since it's C++ library) is using C++ types instead of C

Tested:
- Local build
- By unit-tests