### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(TgBot)
 # options
 option(ENABLE_TESTS "Set to ON to enable building of tests" OFF)
 option(BUILD_SHARED_LIBS "Build tgbot-cpp shared/static library." OFF)
+option(BUILD_DOCUMENTATION "Build doxygen API documentation." OFF)
 
 # sources
 set(CMAKE_CXX_STANDARD 14)
@@ -88,6 +89,17 @@ if (ENABLE_TESTS)
     message(STATUS "Building of tests is enabled")
     enable_testing()
     add_subdirectory(test)
+endif()
+
+# Documentation
+if(BUILD_DOCUMENTATION)
+    find_package(Doxygen REQUIRED)
+    add_custom_target(doc_doxygen ALL
+        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM)
+		install(DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/doc/html/ TYPE DOC)
 endif()
 
 if(MSVC AND BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,6 @@ if(BUILD_DOCUMENTATION)
 		install(DIRECTORY  ${CMAKE_CURRENT_SOURCE_DIR}/doc/html/ TYPE DOC)
 endif()
 
-if(MSVC AND BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
     add_definitions(-DTGBOT_DLL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ else()
 endif()
 include_directories(${Boost_INCLUDE_DIR})
 link_directories(${Boost_LIBRARY_DIR_RELEASE})
+if(NOT Boost_USE_STATIC_LIBS)
+	add_definitions(-DBOOST_ALL_DYN_LINK)
+endif()
 
 set(LIB_LIST
     ${CMAKE_THREAD_LIBS_INIT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,3 +88,7 @@ if (ENABLE_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
+
+if(MSVC AND BUILD_SHARED_LIBS)
+    add_definitions(-DTGBOT_DLL)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ else()
     find_package(Boost 1.59.0 COMPONENTS system REQUIRED)
 endif()
 include_directories(${Boost_INCLUDE_DIR})
+link_directories(${Boost_LIBRARY_DIR_RELEASE})
 
 set(LIB_LIST
     ${CMAKE_THREAD_LIBS_INIT}

--- a/include/tgbot/export.h
+++ b/include/tgbot/export.h
@@ -4,21 +4,21 @@
 #ifndef TGBOT_API
     #ifdef TGBOT_DLL
         #if defined _WIN32 || defined __CYGWIN__
-            #define TGBOT_HELPER_DLL_IMPORT __declspec(dllimport)
             #define TGBOT_HELPER_DLL_EXPORT __declspec(dllexport)
+            #define TGBOT_HELPER_DLL_IMPORT __declspec(dllimport)
         #else
             #if __GNUC__ >= 4
-                #define TGBOT_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
                 #define TGBOT_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+                #define TGBOT_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
             #else
-                #define TGBOT_HELPER_DLL_IMPORT
                 #define TGBOT_HELPER_DLL_EXPORT
+                #define TGBOT_HELPER_DLL_IMPORT
             #endif
         #endif
         #ifdef TgBot_EXPORTS
             #define TGBOT_API TGBOT_HELPER_DLL_EXPORT
         #else
-            #define FOX_API TGBOT_HELPER_DLL_IMPORT
+            #define TGBOT_API TGBOT_HELPER_DLL_IMPORT
         #endif
     #else
         #define TGBOT_API

--- a/include/tgbot/export.h
+++ b/include/tgbot/export.h
@@ -2,19 +2,27 @@
 #define TGBOT_EXPORT_H
 
 #ifndef TGBOT_API
-#ifdef _MSC_VER
-#ifdef TGBOT_DLL
-#ifdef TgBot_EXPORTS
-#define TGBOT_API __declspec(dllexport)
-#else
-#define TGBOT_API __declspec(dllimport)
-#endif
-#else
-#define TGBOT_API
-#endif
-#else
-#define TGBOT_API
-#endif
+    #ifdef TGBOT_DLL
+        #if defined _WIN32 || defined __CYGWIN__
+            #define TGBOT_HELPER_DLL_IMPORT __declspec(dllimport)
+            #define TGBOT_HELPER_DLL_EXPORT __declspec(dllexport)
+        #else
+            #if __GNUC__ >= 4
+                #define TGBOT_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+                #define TGBOT_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+            #else
+                #define TGBOT_HELPER_DLL_IMPORT
+                #define TGBOT_HELPER_DLL_EXPORT
+            #endif
+        #endif
+        #ifdef TgBot_EXPORTS
+            #define TGBOT_API TGBOT_HELPER_DLL_EXPORT
+        #else
+            #define FOX_API TGBOT_HELPER_DLL_IMPORT
+        #endif
+    #else
+        #define TGBOT_API
+    #endif
 #endif
 
 #endif //TGBOT_EXPORT_H

--- a/include/tgbot/export.h
+++ b/include/tgbot/export.h
@@ -2,7 +2,19 @@
 #define TGBOT_EXPORT_H
 
 #ifndef TGBOT_API
+#ifdef _MSC_VER
+#ifdef TGBOT_DLL
+#ifdef TgBot_EXPORTS
+#define TGBOT_API __declspec(dllexport)
+#else
+#define TGBOT_API __declspec(dllimport)
+#endif
+#else
 #define TGBOT_API
+#endif
+#else
+#define TGBOT_API
+#endif
 #endif
 
 #endif //TGBOT_EXPORT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,5 +7,5 @@ set(TEST_SRC_LIST
 
 include_directories("${PROJECT_SOURCE_DIR}/test")
 add_executable(${PROJECT_NAME}_test ${TEST_SRC_LIST})
-target_link_libraries(${PROJECT_NAME}_test TgBot)
+target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})
 add_test(${PROJECT_NAME}_test ${PROJECT_NAME}_test)


### PR DESCRIPTION
Fix issues:
- #138 
- #137 

Add Generation of API documentation to CMake.

Fix to prevent Boost from linking dynamic and static libraries simultaneously when autolink is enabled. Maybe fix #135.