### PR TITLE
Add reply-keyboard sample

### DIFF
--- a/samples/reply-keyboard/src/main.cpp
+++ b/samples/reply-keyboard/src/main.cpp
@@ -1,0 +1,89 @@
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <string>
+#include <vector>
+
+#include <tgbot/tgbot.h>
+
+using namespace std;
+using namespace TgBot;
+
+void createOneColumnKeyboard(const vector<string>& buttonStrings, ReplyKeyboardMarkup::Ptr& kb)
+{
+  for (size_t i = 0; i < buttonStrings.size(); ++i) {
+    vector<KeyboardButton::Ptr> row;
+    KeyboardButton::Ptr button(new KeyboardButton);
+    button->text = buttonStrings[i];
+    row.push_back(button);
+    kb->keyboard.push_back(row);
+  }
+}
+
+void createKeyboard(const vector<vector<string>>& buttonLayout, ReplyKeyboardMarkup::Ptr& kb)
+{
+  for (size_t i = 0; i < buttonLayout.size(); ++i) {
+    vector<KeyboardButton::Ptr> row;
+    for (size_t j = 0; j < buttonLayout[i].size(); ++j) {
+      KeyboardButton::Ptr button(new KeyboardButton);
+      button->text = buttonLayout[i][j];
+      row.push_back(button);
+    }
+    kb->keyboard.push_back(row);
+  }
+}
+
+
+int main() {
+    string token(getenv("TOKEN"));
+    printf("Token: %s\n", token.c_str());
+
+    Bot bot(token);
+
+    ReplyKeyboardMarkup::Ptr keyboardOneCol(new ReplyKeyboardMarkup);
+    createOneColumnKeyboard({"Option 1", "Option 2", "Option 3"}, keyboardOneCol);
+
+    ReplyKeyboardMarkup::Ptr keyboardWithLayout(new ReplyKeyboardMarkup);
+    createKeyboard({
+      {"Dog", "Cat", "Mouse"},
+      {"Green", "White", "Red"},
+      {"On", "Off"},
+      {"Back"},
+      {"Info", "About", "Map", "Etc"}
+    }, keyboardWithLayout);
+
+    bot.getEvents().onCommand("start", [&bot, &keyboardOneCol](Message::Ptr message) {
+        bot.getApi().sendMessage(message->chat->id, "/start for one column keyboard\n/layout for a more complex keyboard", false, 0, keyboardOneCol);
+    });
+    bot.getEvents().onCommand("layout", [&bot, &keyboardWithLayout](Message::Ptr message) {
+        bot.getApi().sendMessage(message->chat->id, "/start for one column keyboard\n/layout for a more complex keyboard", false, 0, keyboardWithLayout);
+    });
+    bot.getEvents().onAnyMessage([&bot](Message::Ptr message) {
+        printf("User wrote %s\n", message->text.c_str());
+        if (StringTools::startsWith(message->text, "/start") || StringTools::startsWith(message->text, "/layout")) {
+            return;
+        }
+        bot.getApi().sendMessage(message->chat->id, "Your message is: " + message->text);
+    });
+
+    signal(SIGINT, [](int s) {
+        printf("SIGINT got\n");
+        exit(0);
+    });
+
+    try {
+        printf("Bot username: %s\n", bot.getApi().getMe()->username.c_str());
+        bot.getApi().deleteWebhook();
+
+        TgLongPoll longPoll(bot);
+        while (true) {
+            printf("Long poll started\n");
+            longPoll.start();
+        }
+    } catch (exception& e) {
+        printf("error: %s\n", e.what());
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I took inspiration from the inline-keyboard sample for my project, and I considered it worthwhile to share my solution with you.
I needed to make many keyboards, so I created a function to quickly populate a keyboard with buttons.
There are two version: one that creates a single column of buttons, which is the one I'm personally using, and another one to create a keyboard with a more complex layout.

I hope you find this example to be useful for future users!
I'm not using CMake or Docker, so let me know if I need to change stuff!