### PR TITLE
Add support to configure the API bot server url

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -46,7 +46,7 @@ typedef std::shared_ptr<std::vector<std::string>> StringArrayPtr;
 friend class Bot;
 
 public:
-    Api(std::string token, const HttpClient& httpClient);
+    Api(std::string token, const HttpClient& httpClient, const std::string& url);
 
     /**
      * @brief A simple method for testing your bot's auth token.
@@ -823,6 +823,7 @@ private:
     const std::string _token;
     const HttpClient& _httpClient;
     const TgTypeParser _tgTypeParser;
+    const std::string _url;
 };
 
 }

--- a/include/tgbot/Bot.h
+++ b/include/tgbot/Bot.h
@@ -21,7 +21,7 @@ class HttpClient;
 class TGBOT_API Bot {
 
 public:
-    explicit Bot(std::string token, const HttpClient &httpClient = _getDefaultHttpClient());
+    explicit Bot(std::string token, const HttpClient &httpClient = _getDefaultHttpClient(), const std::string& url="https://api.telegram.org");
 
     /**
      * @return Token for accessing api.

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -15,8 +15,8 @@ using namespace boost::property_tree;
 
 namespace TgBot {
 
-Api::Api(string token, const HttpClient& httpClient)
-    : _token(std::move(token)), _httpClient(httpClient), _tgTypeParser() {
+Api::Api(string token, const HttpClient& httpClient, const std::string& url)
+    : _token(std::move(token)), _httpClient(httpClient), _tgTypeParser(), _url(url) {
 }
 
 User::Ptr Api::getMe() const {
@@ -1172,7 +1172,8 @@ std::vector<BotCommand::Ptr> Api::getMyCommands() const
 }
 
 ptree Api::sendRequest(const string& method, const vector<HttpReqArg>& args) const {
-    string url = "https://api.telegram.org/bot";
+    string url(_url);
+    url += "/bot";
     url += _token;
     url += "/";
     url += method;
@@ -1195,7 +1196,8 @@ ptree Api::sendRequest(const string& method, const vector<HttpReqArg>& args) con
 }
 
 string Api::downloadFile(const string& filePath, const std::vector<HttpReqArg>& args) const {
-    string url = "https://api.telegram.org/file/bot";
+    string url(_url);
+    url += "/file/bot";
     url += _token;
     url += "/";
     url += filePath;

--- a/src/Bot.cpp
+++ b/src/Bot.cpp
@@ -8,9 +8,9 @@
 
 namespace TgBot {
 
-Bot::Bot(std::string token, const HttpClient& httpClient)
+Bot::Bot(std::string token, const HttpClient& httpClient, const std::string& url)
     : _token(std::move(token))
-    , _api(_token, httpClient)
+    , _api(_token, httpClient, url)
     , _eventBroadcaster(std::make_unique<EventBroadcaster>())
     , _eventHandler(getEvents()) {
 }


### PR DESCRIPTION
Now creating the bot class it is possible to override the API bot
server url that defaults to: 'https://api.telegram.org'
This enables you to connect your bot to the local API bot server.