### PR TITLE
migrate(user-id): from 32-bit integer to 64-bit integer

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -215,7 +215,7 @@ public:
      * @param pngSticker Png image with the sticker, must be up to 512 kilobytes in size, dimensions must not exceed 512px, and either width or height must be exactly 512px.
      * @return Returns the uploaded File on success.
      */
-    File::Ptr uploadStickerFile(std::int32_t userId, InputFile::Ptr pngSticker) const;
+    File::Ptr uploadStickerFile(std::int64_t userId, InputFile::Ptr pngSticker) const;
 
     /**
      * @brief Use this method to create new sticker set owned by a user. The bot will be able to edit the created sticker set.
@@ -228,7 +228,7 @@ public:
      * @param maskPosition Optional. A JSON-serialized object for position where the mask should be placed on faces.
      * @return Returns True on success.
      */
-    bool createNewStickerSet(std::int32_t userId, const std::string& name, const std::string& title,
+    bool createNewStickerSet(std::int64_t userId, const std::string& name, const std::string& title,
                              boost::variant<InputFile::Ptr, std::string> pngSticker, const std::string& emojis, bool containsMasks = false, MaskPosition::Ptr maskPosition = nullptr) const;
 
     /**
@@ -240,7 +240,7 @@ public:
      * @param maskPosition Optional. A JSON-serialized object for position where the mask should be placed on faces.
      * @return Returns True on success.
      */
-    bool addStickerToSet(std::int32_t userId, const std::string& name,
+    bool addStickerToSet(std::int64_t userId, const std::string& name,
                          boost::variant<InputFile::Ptr, std::string> pngSticker, const std::string& emojis, MaskPosition::Ptr maskPosition = nullptr) const;
 
     /**
@@ -440,7 +440,7 @@ public:
      * @param limit Optional. Limits the number of photos to be retrieved. Values between 1—100 are accepted. Defaults to 100.
      * @return A UserProfilePhotos object.
      */
-    UserProfilePhotos::Ptr getUserProfilePhotos(std::int32_t userId, std::int32_t offset = 0, std::int32_t limit = 100) const;
+    UserProfilePhotos::Ptr getUserProfilePhotos(std::int64_t userId, std::int32_t offset = 0, std::int32_t limit = 100) const;
 
     /**
      * @brief Use this method to get basic info about a file and prepare it for downloading. For the moment, bots can download files of up to 20MB in size.
@@ -483,7 +483,7 @@ public:
     * @param userId Unique identifier of the target user
     * @return ChatMember object.
     */
-    ChatMember::Ptr getChatMember(std::int64_t chatId, std::int32_t userId) const;
+    ChatMember::Ptr getChatMember(std::int64_t chatId, std::int64_t userId) const;
 
     /**
     * @brief Use this method to get information about a member of a chat. Returns a ChatMember object on success.
@@ -641,7 +641,7 @@ public:
      * @param untilDate Optional. Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever.
      * @return True on success
      */
-    bool kickChatMember(std::int64_t chatId, std::int32_t userId, std::uint64_t untilDate = 0) const;
+    bool kickChatMember(std::int64_t chatId, std::int64_t userId, std::uint64_t untilDate = 0) const;
 
     /**
      * @brief Use this method to unban a previously kicked user in a supergroup.
@@ -649,7 +649,7 @@ public:
      * @param userId Unique identifier of the target user.
      * @return True on success
      */
-    bool unbanChatMember(std::int64_t chatId, std::int32_t userId) const;
+    bool unbanChatMember(std::int64_t chatId, std::int64_t userId) const;
 
     /**
      * @brief Use this method to restrict a user in a supergroup.
@@ -662,7 +662,7 @@ public:
      * @param canAddWebPagePreviews Optional. Pass True, if the user may add web page previews to their messages, implies can_send_media_messages.
      * @return True on success
      */
-    bool restrictChatMember(std::int64_t chatId, std::int32_t userId, ChatPermissions::Ptr permissions, std::uint64_t untilDate = 0) const;
+    bool restrictChatMember(std::int64_t chatId, std::int64_t userId, ChatPermissions::Ptr permissions, std::uint64_t untilDate = 0) const;
 
     /**
      * @brief Use this method to promote or demote a user in a supergroup or a channel.
@@ -678,7 +678,7 @@ public:
      * @param canPromoteMembers Optional. Pass True, if the administrator can add new administrators with a subset of his own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him).
      * @return True on success
      */
-    bool promoteChatMember(std::int64_t chatId, std::int32_t userId, bool canChangeInfo = false, bool canPostMessages = false,
+    bool promoteChatMember(std::int64_t chatId, std::int64_t userId, bool canChangeInfo = false, bool canPostMessages = false,
                            bool canEditMessages = false, bool canDeleteMessages = false, bool canInviteUsers = false, bool canPinMessages = false, bool canPromoteMembers = false) const;
 
     /**
@@ -766,7 +766,7 @@ public:
      * @param inlineMessageId Optional. Required if chatId and messageId are not specified. Identifier of the inline message
      * @return On success, if the message was sent by the bot, returns the edited Message, otherwise returns nullptr.
      */
-    Message::Ptr setGameScore(std::int32_t userId, std::int32_t score, bool force = false, bool disableEditMessage = false,
+    Message::Ptr setGameScore(std::int64_t userId, std::int32_t score, bool force = false, bool disableEditMessage = false,
                               std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "") const;
 
     /**
@@ -780,7 +780,7 @@ public:
      * @param inlineMessageId Optional. Required if chatId and messageId are not specified. Identifier of the inline message
      * @return On success, returns an Array of GameHighScore objects.
      */
-    std::vector<GameHighScore::Ptr> getGameHighScores(std::int32_t userId, std::int32_t score, bool force = false,
+    std::vector<GameHighScore::Ptr> getGameHighScores(std::int64_t userId, std::int32_t score, bool force = false,
                                                       bool disableEditMessage = false, std::int64_t chatId = 0, std::int32_t messageId = 0, const std::string& inlineMessageId = "") const;
 
     /**

--- a/include/tgbot/types/Contact.h
+++ b/include/tgbot/types/Contact.h
@@ -34,7 +34,7 @@ public:
     /**
      * @brief Optional. Contact's user identifier in Telegram.
      */
-    std::string userId;
+    std::int64_t userId;
 
     /**
      * @brief Optional. Additional data about the contact in the form of a vCard.

--- a/include/tgbot/types/ResponseParameters.h
+++ b/include/tgbot/types/ResponseParameters.h
@@ -22,7 +22,7 @@ public:
      * difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a
      * signed 64 bit integer or double-precision float type are safe for storing this identifier.
      */
-    std::int32_t migrateToChatId;
+    std::int64_t migrateToChatId;
 
     /**
      * @brief Optional. In case of exceeding flood control, the number of seconds left to wait before the request can be repeated

--- a/include/tgbot/types/User.h
+++ b/include/tgbot/types/User.h
@@ -20,7 +20,7 @@ public:
     /**
      * @brief Unique identifier for this user or bot.
      */
-    std::int32_t id;
+    std::int64_t id;
 
     /**
      * @brief True, if this user is a bot

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -312,7 +312,7 @@ StickerSet::Ptr Api::getStickerSet(const string& name) const {
     return _tgTypeParser.parseJsonAndGetStickerSet(sendRequest("getStickerSet", args));
 }
 
-File::Ptr Api::uploadStickerFile(std::int32_t userId, const InputFile::Ptr pngSticker) const {
+File::Ptr Api::uploadStickerFile(std::int64_t userId, const InputFile::Ptr pngSticker) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("user_id", userId);
@@ -320,7 +320,7 @@ File::Ptr Api::uploadStickerFile(std::int32_t userId, const InputFile::Ptr pngSt
     return _tgTypeParser.parseJsonAndGetFile(sendRequest("uploadStickerFile", args));
 }
 
-bool Api::createNewStickerSet(std::int32_t userId, const string& name, const string& title, boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, bool containsMasks, MaskPosition::Ptr maskPosition) const {
+bool Api::createNewStickerSet(std::int64_t userId, const string& name, const string& title, boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, bool containsMasks, MaskPosition::Ptr maskPosition) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);
@@ -342,7 +342,7 @@ bool Api::createNewStickerSet(std::int32_t userId, const string& name, const str
     return sendRequest("createNewStickerSet", args).get<bool>("", false);
 }
 
-bool Api::addStickerToSet(std::int32_t userId, const string& name, boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, MaskPosition::Ptr maskPosition) const {
+bool Api::addStickerToSet(std::int64_t userId, const string& name, boost::variant<InputFile::Ptr, std::string> pngSticker, const string& emojis, MaskPosition::Ptr maskPosition) const {
     vector<HttpReqArg> args;
     args.reserve(6);
     args.emplace_back("user_id", userId);
@@ -698,7 +698,7 @@ void Api::sendChatAction(std::int64_t chatId, const string& action) const {
     sendRequest("sendChatAction", args);
 }
 
-UserProfilePhotos::Ptr Api::getUserProfilePhotos(std::int32_t userId, std::int32_t offset, std::int32_t limit) const {
+UserProfilePhotos::Ptr Api::getUserProfilePhotos(std::int64_t userId, std::int32_t offset, std::int32_t limit) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("user_id", userId);
@@ -875,7 +875,7 @@ Message::Ptr Api::editMessageMedia(InputMedia::Ptr media, std::int64_t chatId, s
     }
 }
 
-ChatMember::Ptr Api::getChatMember(std::int64_t chatId, std::int32_t userId) const {
+ChatMember::Ptr Api::getChatMember(std::int64_t chatId, std::int64_t userId) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
@@ -970,7 +970,7 @@ bool Api::answerInlineQuery(const string& inlineQueryId, const std::vector<Inlin
     return sendRequest("answerInlineQuery", args).get<bool>("", false);
 }
 
-bool Api::kickChatMember(std::int64_t chatId, std::int32_t userId, std::uint64_t untilDate) const {
+bool Api::kickChatMember(std::int64_t chatId, std::int64_t userId, std::uint64_t untilDate) const {
     vector<HttpReqArg> args;
     args.reserve(3);
     args.emplace_back("chat_id", chatId);
@@ -981,14 +981,14 @@ bool Api::kickChatMember(std::int64_t chatId, std::int32_t userId, std::uint64_t
     return sendRequest("kickChatMember", args).get<bool>("", false);
 }
 
-bool Api::unbanChatMember(std::int64_t chatId, std::int32_t userId) const {
+bool Api::unbanChatMember(std::int64_t chatId, std::int64_t userId) const {
     vector<HttpReqArg> args;
     args.reserve(2);
     args.emplace_back("chat_id", chatId);
     args.emplace_back("user_id", userId);
     return sendRequest("unbanChatMember", args).get<bool>("", false);
 }
-bool Api::restrictChatMember(std::int64_t chatId, std::int32_t userId, TgBot::ChatPermissions::Ptr permissions,
+bool Api::restrictChatMember(std::int64_t chatId, std::int64_t userId, TgBot::ChatPermissions::Ptr permissions,
                              std::uint64_t untilDate) const {
     vector<HttpReqArg> args;
     args.reserve(4);
@@ -1002,7 +1002,7 @@ bool Api::restrictChatMember(std::int64_t chatId, std::int32_t userId, TgBot::Ch
     return sendRequest("restrictChatMember", args).get<bool>("", false);
 }
 
-bool Api::promoteChatMember(std::int64_t chatId, std::int32_t userId, bool canChangeInfo, bool canPostMessages,
+bool Api::promoteChatMember(std::int64_t chatId, std::int64_t userId, bool canChangeInfo, bool canPostMessages,
                             bool canEditMessages, bool canDeleteMessages, bool canInviteUsers, bool canPinMessages, bool canPromoteMembers) const {
     vector<HttpReqArg> args;
     args.reserve(9);
@@ -1096,7 +1096,7 @@ bool Api::unpinChatMessage(std::int64_t chatId) const {
     return sendRequest("unpinChatMessage", args).get<bool>("", false);
 }
 
-Message::Ptr Api::setGameScore(std::int32_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
+Message::Ptr Api::setGameScore(std::int64_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);
@@ -1119,7 +1119,7 @@ Message::Ptr Api::setGameScore(std::int32_t userId, std::int32_t score, bool for
     return _tgTypeParser.parseJsonAndGetMessage(sendRequest("setGameScore", args));
 }
 
-vector<GameHighScore::Ptr> Api::getGameHighScores(std::int32_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
+vector<GameHighScore::Ptr> Api::getGameHighScores(std::int64_t userId, std::int32_t score, bool force, bool disableEditMessage, std::int64_t chatId, std::int32_t messageId, const std::string& inlineMessageId) const {
     vector<HttpReqArg> args;
     args.reserve(7);
     args.emplace_back("user_id", userId);

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -63,7 +63,7 @@ string TgTypeParser::parseChat(const Chat::Ptr& object) const {
 
 User::Ptr TgTypeParser::parseJsonAndGetUser(const ptree& data) const {
     auto result(make_shared<User>());
-    result->id = data.get<int32_t>("id");
+    result->id = data.get<int64_t>("id");
     result->isBot = data.get<bool>("is_bot", false);
     result->firstName = data.get<string>("first_name");
     result->lastName = data.get("last_name", "");
@@ -613,7 +613,7 @@ Contact::Ptr TgTypeParser::parseJsonAndGetContact(const ptree& data) const {
     result->phoneNumber = data.get<string>("phone_number");
     result->firstName = data.get<string>("first_name");
     result->lastName = data.get("last_name", "");
-    result->userId = data.get("user_id", "");
+    result->userId = data.get("user_id", 0);
     result->vcard = data.get("vcard", "");
     return result;
 }
@@ -988,7 +988,7 @@ std::string TgTypeParser::parseChatPhoto(const ChatPhoto::Ptr& object) const {
 
 ResponseParameters::Ptr TgTypeParser::parseJsonAndGetResponseParameters(const boost::property_tree::ptree& data) const {
     auto result(make_shared<ResponseParameters>());
-    result->migrateToChatId = data.get<int32_t>("migrate_to_chat_id", 0);
+    result->migrateToChatId = data.get<int64_t>("migrate_to_chat_id", 0);
     result->retryAfter = data.get<int32_t>("retry_after", 0);
     return result;
 }

--- a/src/net/CurlHttpClient.cpp
+++ b/src/net/CurlHttpClient.cpp
@@ -2,8 +2,6 @@
 
 #include "tgbot/net/CurlHttpClient.h"
 
-#include <boost/asio/ssl.hpp>
-
 #include <cstddef>
 #include <string>
 

--- a/src/net/HttpParser.cpp
+++ b/src/net/HttpParser.cpp
@@ -57,11 +57,11 @@ string HttpParser::generateRequest(const Url& url, const vector<HttpReqArg>& arg
     return result;
 }
 
-string HttpParser::generateMultipartFormData(const vector<HttpReqArg>& args, const string& bondary) const {
+string HttpParser::generateMultipartFormData(const vector<HttpReqArg>& args, const string& boundary) const {
     string result;
     for (const HttpReqArg& item : args) {
         result += "--";
-        result += bondary;
+        result += boundary;
         result += "\r\nContent-Disposition: form-data; name=\"";
         result += item.name;
         if (item.isFile) {
@@ -77,7 +77,7 @@ string HttpParser::generateMultipartFormData(const vector<HttpReqArg>& args, con
         result += item.value;
         result += "\r\n";
     }
-    result += "--" + bondary + "--\r\n";
+    result += "--" + boundary + "--\r\n";
     return result;
 }
 


### PR DESCRIPTION
# Fixed issue

- fix #187 
- fix #186
- fix #181
- fix typo

# BC Break

## Heavy

### include/tgbot/types/Contact.h

- changed type of `userId` from `std::string` to `std::int64_t`.

## Small

- changed type of every `userId` from 32-bit integer to 64-bit integer.
