### PR TITLE
Update to Bot API 6.5

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Documentation is located [here](http://reo7sp.github.io/tgbot-cpp).
 
 ## State
 
-- [x] Bot API 3.0 ~ 6.4
+- [x] Telegram Bot API 6.5
 
 
 ## Sample

--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -770,7 +770,7 @@ public:
      * @brief Use this method to get basic information about a file and prepare it for downloading.
      * 
      * For the moment, bots can download files of up to 20MB in size.
-     * The file can then be downloaded via Api::downloadFile, where filePath is taken from the response.
+     * The file can then be downloaded via Api::downloadFile or via the link https://api.telegram.org/file/bot<token>/<filePath>, where filePath is taken from the response.
      * It is guaranteed that the filePath will be valid for at least 1 hour.
      * When the link expires, a new one can be requested by calling Api::getFile again.
      * 
@@ -823,20 +823,22 @@ public:
     /**
      * @brief Use this method to restrict a user in a supergroup.
      * 
-     * The bot must be an administrator in the supergroup for this to work and must have the appropriate admin rights.
+     * The bot must be an administrator in the supergroup for this to work and must have the appropriate administrator rights.
      * Pass True for all permissions to lift restrictions from a user.
      * 
      * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
      * @param userId Unique identifier of the target user
      * @param permissions A JSON-serialized object for new user permissions
      * @param untilDate Optional. Date when restrictions will be lifted for the user, unix time. If user is restricted for more than 366 days or less than 30 seconds from the current time, they are considered to be restricted forever
+     * @param useIndependentChatPermissions Optional. Pass True if chat permissions are set independently. Otherwise, the canSendOtherMessages and canAddWebPagPreviews permissions will imply the canSendMessages, canSendAudios, canSendDocuments, canSendPhotos, canSendVideos, canSendVideoNotes, and canSendVoiceNotes permissions; the canSendPolls permission will imply the canSendMessages permission.
      * 
      * @return Returns True on success.
      */
     bool restrictChatMember(boost::variant<std::int64_t, std::string> chatId,
                             std::int64_t userId,
                             ChatPermissions::Ptr permissions,
-                            std::int64_t untilDate = 0) const;
+                            std::int64_t untilDate = 0,
+                            bool useIndependentChatPermissions = false) const;
 
     /**
      * @brief Use this method to promote or demote a user in a supergroup or a channel.
@@ -852,7 +854,7 @@ public:
      * @param canDeleteMessages Optional. Pass True if the administrator can delete messages of other users
      * @param canInviteUsers Optional. Pass True if the administrator can invite new users to the chat
      * @param canPinMessages Optional. Pass True if the administrator can pin messages, supergroups only
-     * @param canPromoteMembers Optional. Pass True if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by him)
+     * @param canPromoteMembers Optional. Pass True if the administrator can add new administrators with a subset of their own privileges or demote administrators that they have promoted, directly or indirectly (promoted by administrators that were appointed by him)
      * @param isAnonymous Optional. Pass True if the administrator's presence in the chat is hidden
      * @param canManageChat Optional. Pass True if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
      * @param canManageVideoChats Optional. Pass True if the administrator can manage video chats
@@ -923,11 +925,13 @@ public:
      * 
      * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
      * @param permissions A JSON-serialized object for new default chat permissions
+     * @param useIndependentChatPermissions Optional. Pass True if chat permissions are set independently. Otherwise, the canSendOtherMessages and canAddWebPagPreviews permissions will imply the canSendMessages, canSendAudios, canSendDocuments, canSendPhotos, canSendVideos, canSendVideoNotes, and canSendVoiceNotes permissions; the canSendPolls permission will imply the canSendMessages permission.
      * 
      * @return Returns True on success.
      */
     bool setChatPermissions(boost::variant<std::int64_t, std::string> chatId,
-                            ChatPermissions::Ptr permissions) const;
+                            ChatPermissions::Ptr permissions,
+                            bool useIndependentChatPermissions = false) const;
 
     /**
      * @brief Use this method to generate a new primary invite link for a chat; any previously generated primary link is revoked.
@@ -1157,7 +1161,7 @@ public:
     /**
      * @brief Use this method to get information about a member of a chat.
      * 
-     * The method is guaranteed to work for other users, only if the bot is an administrator in the chat.
+     * The method is only guaranteed to work for other users if the bot is an administrator in the chat.
      * 
      * @param chatId Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
      * @param userId Unique identifier of the target user
@@ -1207,7 +1211,7 @@ public:
      * 
      * @param chatId Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
      * @param name Topic name, 1-128 characters
-     * @param iconColor Optional. Color of the topic icon in RGB format. Currently, must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, or 0xFB6F5F
+     * @param iconColor Optional. Color of the topic icon in RGB format. Currently, must be one of 7322096 (0x6FB9F0), 16766590 (0xFFD67E), 13338331 (0xCB86DB), 9367192 (0x8EEE98), 16749490 (0xFF93B2), or 16478047 (0xFB6F5F)
      * @param iconCustomEmojiId Optional. Unique identifier of the custom emoji shown as the topic icon. Use Api::getForumTopicIconStickers to get all allowed custom emoji identifiers.
      * 
      * @return Returns information about the created topic as a ForumTopic object.

--- a/include/tgbot/TgTypeParser.h
+++ b/include/tgbot/TgTypeParser.h
@@ -32,6 +32,8 @@
 #include "tgbot/types/ForumTopicReopened.h"
 #include "tgbot/types/GeneralForumTopicHidden.h"
 #include "tgbot/types/GeneralForumTopicUnhidden.h"
+#include "tgbot/types/UserShared.h"
+#include "tgbot/types/ChatShared.h"
 #include "tgbot/types/WriteAccessAllowed.h"
 #include "tgbot/types/VideoChatScheduled.h"
 #include "tgbot/types/VideoChatStarted.h"
@@ -42,6 +44,8 @@
 #include "tgbot/types/WebAppInfo.h"
 #include "tgbot/types/ReplyKeyboardMarkup.h"
 #include "tgbot/types/KeyboardButton.h"
+#include "tgbot/types/KeyboardButtonRequestUser.h"
+#include "tgbot/types/KeyboardButtonRequestChat.h"
 #include "tgbot/types/KeyboardButtonPollType.h"
 #include "tgbot/types/ReplyKeyboardRemove.h"
 #include "tgbot/types/InlineKeyboardMarkup.h"
@@ -252,6 +256,12 @@ public:
     GeneralForumTopicUnhidden::Ptr parseJsonAndGetGeneralForumTopicUnhidden(const boost::property_tree::ptree& data) const;
     std::string parseGeneralForumTopicUnhidden(const GeneralForumTopicUnhidden::Ptr& object) const;
 
+    UserShared::Ptr parseJsonAndGetUserShared(const boost::property_tree::ptree& data) const;
+    std::string parseUserShared(const UserShared::Ptr& object) const;
+
+    ChatShared::Ptr parseJsonAndGetChatShared(const boost::property_tree::ptree& data) const;
+    std::string parseChatShared(const ChatShared::Ptr& object) const;
+
     WriteAccessAllowed::Ptr parseJsonAndGetWriteAccessAllowed(const boost::property_tree::ptree& data) const;
     std::string parseWriteAccessAllowed(const WriteAccessAllowed::Ptr& object) const;
 
@@ -281,6 +291,12 @@ public:
 
     KeyboardButton::Ptr parseJsonAndGetKeyboardButton(const boost::property_tree::ptree& data) const;
     std::string parseKeyboardButton(const KeyboardButton::Ptr& object) const;
+
+    KeyboardButtonRequestUser::Ptr parseJsonAndGetKeyboardButtonRequestUser(const boost::property_tree::ptree& data) const;
+    std::string parseKeyboardButtonRequestUser(const KeyboardButtonRequestUser::Ptr& object) const;
+
+    KeyboardButtonRequestChat::Ptr parseJsonAndGetKeyboardButtonRequestChat(const boost::property_tree::ptree& data) const;
+    std::string parseKeyboardButtonRequestChat(const KeyboardButtonRequestChat::Ptr& object) const;
 
     KeyboardButtonPollType::Ptr parseJsonAndGetKeyboardButtonPollType(const boost::property_tree::ptree& data) const;
     std::string parseKeyboardButtonPollType(const KeyboardButtonPollType::Ptr& object) const;

--- a/include/tgbot/types/ChatAdministratorRights.h
+++ b/include/tgbot/types/ChatAdministratorRights.h
@@ -42,7 +42,7 @@ public:
     bool canRestrictMembers;
 
     /**
-     * @brief True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+     * @brief True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that they have promoted, directly or indirectly (promoted by administrators that were appointed by the user)
      */
     bool canPromoteMembers;
 

--- a/include/tgbot/types/ChatJoinRequest.h
+++ b/include/tgbot/types/ChatJoinRequest.h
@@ -1,5 +1,5 @@
-#ifndef TGBOT_CPP_CHATJOINREQUEST_H
-#define TGBOT_CPP_CHATJOINREQUEST_H
+#ifndef TGBOT_CHATJOINREQUEST_H
+#define TGBOT_CHATJOINREQUEST_H
 
 #include "tgbot/types/Chat.h"
 #include "tgbot/types/User.h"
@@ -32,6 +32,16 @@ public:
     User::Ptr from;
 
     /**
+     * @brief Identifier of a private chat with the user who sent the join request.
+     * 
+     * The bot can use this identifier for 24 hours to send messages until the join request is processed, assuming no other administrator contacted the user.
+     * 
+     * This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
+     */
+    std::int64_t userChatId;
+
+    /**
      * @brief Date the request was sent in Unix time
      */
     std::int32_t date;
@@ -48,4 +58,4 @@ public:
 };
 }
 
-#endif //TGBOT_CPP_CHATJOINREQUEST_H
+#endif //TGBOT_CHATJOINREQUEST_H

--- a/include/tgbot/types/ChatMemberAdministrator.h
+++ b/include/tgbot/types/ChatMemberAdministrator.h
@@ -56,7 +56,7 @@ public:
     bool canRestrictMembers;
 
     /**
-     * @brief True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+     * @brief True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that they have promoted, directly or indirectly (promoted by administrators that were appointed by the user)
      */
     bool canPromoteMembers;
 

--- a/include/tgbot/types/ChatMemberRestricted.h
+++ b/include/tgbot/types/ChatMemberRestricted.h
@@ -31,6 +31,56 @@ public:
     bool isMember;
 
     /**
+     * @brief True, if the user is allowed to send text messages, contacts, invoices, locations and venues
+     */
+    bool canSendMessages;
+
+    /**
+     * @brief True, if the user is allowed to send audios
+     */
+    bool canSendAudios;
+
+    /**
+     * @brief True, if the user is allowed to send documents
+     */
+    bool canSendDocuments;
+
+    /**
+     * @brief True, if the user is allowed to send photos
+     */
+    bool canSendPhotos;
+
+    /**
+     * @brief True, if the user is allowed to send videos
+     */
+    bool canSendVideos;
+
+    /**
+     * @brief True, if the user is allowed to send video notes
+     */
+    bool canSendVideoNotes;
+
+    /**
+     * @brief True, if the user is allowed to send voice notes
+     */
+    bool canSendVoiceNotes;
+
+    /**
+     * @brief True, if the user is allowed to send polls
+     */
+    bool canSendPolls;
+
+    /**
+     * @brief True, if the user is allowed to send animations, games, stickers and use inline bots
+     */
+    bool canSendOtherMessages;
+
+    /**
+     * @brief True, if the user is allowed to add web page previews to their messages
+     */
+    bool canAddWebPagePreviews;
+
+    /**
      * @brief True, if the user is allowed to change the chat title, photo and other settings
      */
     bool canChangeInfo;
@@ -49,31 +99,6 @@ public:
      * @brief True, if the user is allowed to create forum topics
      */
     bool canManageTopics;
-
-    /**
-     * @brief True, if the user is allowed to send text messages, contacts, locations and venues
-     */
-    bool canSendMessages;
-
-    /**
-     * @brief True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes
-     */
-    bool canSendMediaMessages;
-
-    /**
-     * @brief True, if the user is allowed to send polls
-     */
-    bool canSendPolls;
-
-    /**
-     * @brief True, if the user is allowed to send animations, games, stickers and use inline bots
-     */
-    bool canSendOtherMessages;
-
-    /**
-     * @brief True, if the user is allowed to add web page previews to their messages
-     */
-    bool canAddWebPagePreviews;
 
     /**
      * @brief Date when restrictions will be lifted for this user; unix time.

--- a/include/tgbot/types/ChatPermissions.h
+++ b/include/tgbot/types/ChatPermissions.h
@@ -16,14 +16,39 @@ public:
     typedef std::shared_ptr<ChatPermissions> Ptr;
 
     /**
-     * @brief Optional. True, if the user is allowed to send text messages, contacts, locations and venues
+     * @brief Optional. True, if the user is allowed to send text messages, contacts, invoices, locations and venues
      */
     bool canSendMessages;
 
     /**
-     * @brief Optional. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes, implies canSendMessages
+     * @brief Optional. True, if the user is allowed to send audios
      */
-    bool canSendMediaMessages;
+    bool canSendAudios;
+
+    /**
+     * @brief Optional. True, if the user is allowed to send documents
+     */
+    bool canSendDocuments;
+
+    /**
+     * @brief Optional. True, if the user is allowed to send photos
+     */
+    bool canSendPhotos;
+
+    /**
+     * @brief Optional. True, if the user is allowed to send videos
+     */
+    bool canSendVideos;
+
+    /**
+     * @brief Optional. True, if the user is allowed to send video notes
+     */
+    bool canSendVideoNotes;
+
+    /**
+     * @brief Optional. True, if the user is allowed to send voice notes
+     */
+    bool canSendVoiceNotes;
 
     /**
      * @brief Optional. True, if the user is allowed to send polls, implies canSendMessages

--- a/include/tgbot/types/ChatShared.h
+++ b/include/tgbot/types/ChatShared.h
@@ -1,0 +1,36 @@
+#ifndef TGBOT_CHATSHARED_H
+#define TGBOT_CHATSHARED_H
+
+#include <cstdint>
+#include <memory>
+
+namespace TgBot {
+
+/**
+ * @brief This object contains information about the chat whose identifier was shared with the bot using a KeyboardButtonRequestChat button.
+ *
+ * @ingroup types
+ */
+class ChatShared  {
+
+public:
+    typedef std::shared_ptr<ChatShared> Ptr;
+
+    /**
+     * @brief Identifier of the request
+     */
+    std::int32_t requestId;
+
+    /**
+     * @brief Identifier of the shared chat.
+     * 
+     * The bot may not have access to the chat and could be unable to use this identifier, unless the chat is already known to the bot by some other means.
+     * 
+     * This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
+     */
+    std::int64_t userId;
+};
+}
+
+#endif //TGBOT_CHATSHARED_H

--- a/include/tgbot/types/File.h
+++ b/include/tgbot/types/File.h
@@ -9,7 +9,7 @@ namespace TgBot {
 
 /**
  * @brief This object represents a file ready to be downloaded.
- * The file can be downloaded via Api::downloadFile.
+ * The file can be downloaded via Api::downloadFile or via the link https://api.telegram.org/file/bot<token>/<filePath>.
  * It is guaranteed that the File::filePath will be valid for at least 1 hour.
  * When the File::filePath expires, a new one can be requested by calling Api::getFile.
  * 
@@ -43,7 +43,7 @@ public:
 
     /**
      * @brief Optional. File path.
-     * Use Api::downloadFile to get the file.
+     * Use Api::downloadFile or https://api.telegram.org/file/bot<token>/<filePath> to get the file.
      */
     std::string filePath;
 };

--- a/include/tgbot/types/KeyboardButton.h
+++ b/include/tgbot/types/KeyboardButton.h
@@ -1,6 +1,8 @@
 #ifndef TGBOT_KEYBOARDBUTTON_H
 #define TGBOT_KEYBOARDBUTTON_H
 
+#include "tgbot/types/KeyboardButtonRequestUser.h"
+#include "tgbot/types/KeyboardButtonRequestChat.h"
 #include "tgbot/types/KeyboardButtonPollType.h"
 #include "tgbot/types/WebAppInfo.h"
 
@@ -11,8 +13,8 @@ namespace TgBot {
 
 /**
  * @brief This object represents one button of the reply keyboard.
- * For simple text buttons String can be used instead of this object to specify text of the button.
- * Optional fields webApp, requestContact, requestLocation, and requestPoll are mutually exclusive.
+ * For simple text buttons, String can be used instead of this object to specify the button text.
+ * The optional fields webApp, requestUser, requestChat, requestContact, requestLocation, and requestPoll are mutually exclusive.
  *
  * @ingroup types
  */
@@ -23,31 +25,52 @@ public:
 
     /**
      * @brief Text of the button.
+     * 
      * If none of the optional fields are used, it will be sent as a message when the button is pressed
      */
     std::string text;
 
     /**
-     * @brief Optional. If True, the user's phone number will be sent as a contact when the button is pressed.
+     * @brief Optional. If specified, pressing the button will open a list of suitable users.
+     * 
+     * Tapping on any user will send their identifier to the bot in a “user_shared” service message.
      * Available in private chats only.
      */
-    bool requestContact = false;
+    KeyboardButtonRequestUser::Ptr requestUser;
+
+    /**
+     * @brief Optional. If specified, pressing the button will open a list of suitable chats.
+     * 
+     * Tapping on a chat will send its identifier to the bot in a “chat_shared” service message.
+     * Available in private chats only.
+     */
+    KeyboardButtonRequestChat::Ptr requestChat;
+
+    /**
+     * @brief Optional. If True, the user's phone number will be sent as a contact when the button is pressed.
+     * 
+     * Available in private chats only.
+     */
+    bool requestContact;
 
     /**
      * @brief Optional. If True, the user's current location will be sent when the button is pressed.
+     * 
      * Available in private chats only.
      */
-    bool requestLocation = false;
+    bool requestLocation;
 
     /**
      * @brief Optional. If specified, the user will be asked to create a poll and send it to the bot when the button is pressed.
+     * 
      * Available in private chats only.
      */
     KeyboardButtonPollType::Ptr requestPoll;
 
     /**
      * @brief Optional. If specified, the described Web App will be launched when the button is pressed.
-     * The Web App will be able to send a “web_app_data” service message. 
+     * 
+     * The Web App will be able to send a “web_app_data” service message.
      * Available in private chats only.
      */
     WebAppInfo::Ptr webApp;

--- a/include/tgbot/types/KeyboardButtonRequestChat.h
+++ b/include/tgbot/types/KeyboardButtonRequestChat.h
@@ -1,0 +1,80 @@
+#ifndef TGBOT_KEYBOARDBUTTONREQUESTCHAT_H
+#define TGBOT_KEYBOARDBUTTONREQUESTCHAT_H
+
+#include "tgbot/types/ChatAdministratorRights.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace TgBot {
+
+/**
+ * @brief This object defines the criteria used to request a suitable chat.
+ * The identifier of the selected chat will be shared with the bot when the corresponding button is pressed.
+ *
+ * @ingroup types
+ */
+class KeyboardButtonRequestChat {
+
+public:
+    typedef std::shared_ptr<KeyboardButtonRequestChat> Ptr;
+
+    /**
+     * @brief Signed 32-bit identifier of the request, which will be received back in the ChatShared object.
+     * 
+     * Must be unique within the message
+     */
+    std::int32_t requestId;
+
+    /**
+     * @brief Pass True to request a channel chat, pass False to request a group or a supergroup chat.
+     */
+    bool chatIsChannel;
+
+    /**
+     * @brief Optional. Pass True to request a forum supergroup, pass False to request a non-forum chat.
+     * 
+     * If not specified, no additional restrictions are applied.
+     */
+    bool chatIsForum;
+
+    /**
+     * @brief Optional. Pass True to request a supergroup or a channel with a username, pass False to request a chat without a username.
+     * 
+     * If not specified, no additional restrictions are applied.
+     */
+    bool chatHasUsername;
+
+    /**
+     * @brief Optional. Pass True to request a chat owned by the user.
+     * 
+     * Otherwise, no additional restrictions are applied.
+     */
+    bool chatIsCreated;
+
+    /**
+     * @brief Optional. A JSON-serialized object listing the required administrator rights of the user in the chat.
+     * 
+     * The rights must be a superset of bot_administrator_rights.
+     * If not specified, no additional restrictions are applied.
+     */
+    ChatAdministratorRights::Ptr userAdministratorRights;
+
+    /**
+     * @brief Optional. A JSON-serialized object listing the required administrator rights of the bot in the chat.
+     * 
+     * The rights must be a subset of user_administrator_rights.
+     * If not specified, no additional restrictions are applied.
+     */
+    ChatAdministratorRights::Ptr botAdministratorRights;
+
+    /**
+     * @brief Optional. Pass True to request a chat with the bot as a member.
+     * 
+     * Otherwise, no additional restrictions are applied.
+     */
+    bool botIsMember;
+};
+}
+
+#endif //TGBOT_KEYBOARDBUTTONREQUESTCHAT_H

--- a/include/tgbot/types/KeyboardButtonRequestUser.h
+++ b/include/tgbot/types/KeyboardButtonRequestUser.h
@@ -1,0 +1,43 @@
+#ifndef TGBOT_KEYBOARDBUTTONREQUESTUSER_H
+#define TGBOT_KEYBOARDBUTTONREQUESTUSER_H
+
+#include <cstdint>
+#include <memory>
+
+namespace TgBot {
+
+/**
+ * @brief This object defines the criteria used to request a suitable user.
+ * The identifier of the selected user will be shared with the bot when the corresponding button is pressed.
+ *
+ * @ingroup types
+ */
+class KeyboardButtonRequestUser {
+
+public:
+    typedef std::shared_ptr<KeyboardButtonRequestUser> Ptr;
+
+    /**
+     * @brief Signed 32-bit identifier of the request, which will be received back in the UserShared object.
+     * 
+     * Must be unique within the message
+     */
+    std::int32_t requestId;
+
+    /**
+     * @brief Optional. Pass True to request a bot, pass False to request a regular user.
+     * 
+     * If not specified, no additional restrictions are applied.
+     */
+    bool userIsBot;
+
+    /**
+     * @brief Optional. Pass True to request a premium user, pass False to request a non-premium user.
+     * 
+     * If not specified, no additional restrictions are applied.
+     */
+    bool userIsPremium;
+};
+}
+
+#endif //TGBOT_KEYBOARDBUTTONREQUESTUSER_H

--- a/include/tgbot/types/Message.h
+++ b/include/tgbot/types/Message.h
@@ -22,6 +22,8 @@
 #include "tgbot/types/MessageAutoDeleteTimerChanged.h"
 #include "tgbot/types/Invoice.h"
 #include "tgbot/types/SuccessfulPayment.h"
+#include "tgbot/types/UserShared.h"
+#include "tgbot/types/ChatShared.h"
 #include "tgbot/types/WriteAccessAllowed.h"
 #include "tgbot/types/PassportData.h"
 #include "tgbot/types/ProximityAlertTriggered.h"
@@ -347,6 +349,16 @@ public:
      * https://core.telegram.org/bots/api#payments
      */
     SuccessfulPayment::Ptr successfulPayment;
+
+    /**
+     * @brief Optional. Service message: a user was shared with the bot
+     */
+    UserShared::Ptr userShared;
+
+    /**
+     * @brief Optional. Service message: a chat was shared with the bot
+     */
+    ChatShared::Ptr chatShared;
 
     /**
      * @brief Optional. The domain name of the website on which the user has logged in.

--- a/include/tgbot/types/UserShared.h
+++ b/include/tgbot/types/UserShared.h
@@ -1,0 +1,36 @@
+#ifndef TGBOT_USERSHARED_H
+#define TGBOT_USERSHARED_H
+
+#include <cstdint>
+#include <memory>
+
+namespace TgBot {
+
+/**
+ * @brief This object contains information about the user whose identifier was shared with the bot using a KeyboardButtonRequestUser button.
+ *
+ * @ingroup types
+ */
+class UserShared  {
+
+public:
+    typedef std::shared_ptr<UserShared> Ptr;
+
+    /**
+     * @brief Identifier of the request
+     */
+    std::int32_t requestId;
+
+    /**
+     * @brief Identifier of the shared user.
+     * 
+     * The bot may not have access to the user and could be unable to use this identifier, unless the user is already known to the bot by some other means.
+     * 
+     * This number may have more than 32 significant bits and some programming languages may have difficulty/silent defects in interpreting it.
+     * But it has at most 52 significant bits, so a 64-bit integer or double-precision float type are safe for storing this identifier.
+     */
+    std::int64_t userId;
+};
+}
+
+#endif //TGBOT_USERSHARED_H

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1141,13 +1141,17 @@ bool Api::unbanChatMember(boost::variant<std::int64_t, std::string> chatId,
 bool Api::restrictChatMember(boost::variant<std::int64_t, std::string> chatId,
                              std::int64_t userId,
                              TgBot::ChatPermissions::Ptr permissions,
-                             std::int64_t untilDate) const {
+                             std::int64_t untilDate,
+                             bool useIndependentChatPermissions) const {
     std::vector<HttpReqArg> args;
-    args.reserve(4);
+    args.reserve(5);
 
     args.emplace_back("chat_id", chatId);
     args.emplace_back("user_id", userId);
     args.emplace_back("permissions", _tgTypeParser.parseChatPermissions(permissions));
+    if (useIndependentChatPermissions) {
+        args.emplace_back("use_independent_chat_permissions", useIndependentChatPermissions);
+    }
     if (untilDate) {
         args.emplace_back("until_date", untilDate);
     }
@@ -1250,12 +1254,16 @@ bool Api::unbanChatSenderChat(boost::variant<std::int64_t, std::string> chatId,
 }
 
 bool Api::setChatPermissions(boost::variant<std::int64_t, std::string> chatId,
-                             ChatPermissions::Ptr permissions) const {
+                             ChatPermissions::Ptr permissions,
+                             bool useIndependentChatPermissions) const {
     std::vector<HttpReqArg> args;
-    args.reserve(2);
+    args.reserve(3);
 
     args.emplace_back("chat_id", chatId);
     args.emplace_back("permissions", _tgTypeParser.parseChatPermissions(permissions));
+    if (useIndependentChatPermissions) {
+        args.emplace_back("use_independent_chat_permissions", useIndependentChatPermissions);
+    }
 
     return sendRequest("setChatPermissions", args).get<bool>("", false);
 }

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -278,6 +278,8 @@ Message::Ptr TgTypeParser::parseJsonAndGetMessage(const boost::property_tree::pt
     result->pinnedMessage = tryParseJson<Message>(&TgTypeParser::parseJsonAndGetMessage, data, "pinned_message");
     result->invoice = tryParseJson<Invoice>(&TgTypeParser::parseJsonAndGetInvoice, data, "invoice");
     result->successfulPayment = tryParseJson<SuccessfulPayment>(&TgTypeParser::parseJsonAndGetSuccessfulPayment, data, "successful_payment");
+    result->userShared = tryParseJson<UserShared>(&TgTypeParser::parseJsonAndGetUserShared, data, "user_shared");
+    result->chatShared = tryParseJson<ChatShared>(&TgTypeParser::parseJsonAndGetChatShared, data, "chat_shared");
     result->connectedWebsite = data.get<std::string>("connected_website", "");
     result->writeAccessAllowed = tryParseJson<WriteAccessAllowed>(&TgTypeParser::parseJsonAndGetWriteAccessAllowed, data, "write_access_allowed");
     result->passportData = tryParseJson<PassportData>(&TgTypeParser::parseJsonAndGetPassportData, data, "passport_data");
@@ -356,6 +358,8 @@ std::string TgTypeParser::parseMessage(const Message::Ptr& object) const {
     appendToJson(result, "pinned_message", parseMessage(object->pinnedMessage));
     appendToJson(result, "invoice", parseInvoice(object->invoice));
     appendToJson(result, "successful_payment", parseSuccessfulPayment(object->successfulPayment));
+    appendToJson(result, "user_shared", parseUserShared(object->userShared));
+    appendToJson(result, "chat_shared", parseChatShared(object->chatShared));
     appendToJson(result, "connected_website", object->connectedWebsite);
     appendToJson(result, "write_access_allowed", parseWriteAccessAllowed(object->writeAccessAllowed));
     appendToJson(result, "passport_data", parsePassportData(object->passportData));
@@ -1063,6 +1067,46 @@ std::string TgTypeParser::parseGeneralForumTopicUnhidden(const GeneralForumTopic
     return result;
 }
 
+UserShared::Ptr TgTypeParser::parseJsonAndGetUserShared(const boost::property_tree::ptree& data) const {
+    auto result(std::make_shared<UserShared>());
+    result->requestId = data.get<std::int32_t>("request_id", 0);
+    result->userId = data.get<std::int64_t>("user_id", 0);
+    return result;
+}
+
+std::string TgTypeParser::parseUserShared(const UserShared::Ptr& object) const {
+    if (!object) {
+        return "";
+    }
+    std::string result;
+    result += '{';
+    appendToJson(result, "request_id", object->requestId);
+    appendToJson(result, "user_id", object->userId);
+    removeLastComma(result);
+    result += '}';
+    return result;
+}
+
+ChatShared::Ptr TgTypeParser::parseJsonAndGetChatShared(const boost::property_tree::ptree& data) const {
+    auto result(std::make_shared<ChatShared>());
+    result->requestId = data.get<std::int32_t>("request_id", 0);
+    result->userId = data.get<std::int64_t>("user_id", 0);
+    return result;
+}
+
+std::string TgTypeParser::parseChatShared(const ChatShared::Ptr& object) const {
+    if (!object) {
+        return "";
+    }
+    std::string result;
+    result += '{';
+    appendToJson(result, "request_id", object->requestId);
+    appendToJson(result, "user_id", object->userId);
+    removeLastComma(result);
+    result += '}';
+    return result;
+}
+
 WriteAccessAllowed::Ptr TgTypeParser::parseJsonAndGetWriteAccessAllowed(const boost::property_tree::ptree& data) const {
     auto result(std::make_shared<WriteAccessAllowed>());
     return result;
@@ -1255,6 +1299,8 @@ std::string TgTypeParser::parseReplyKeyboardMarkup(const ReplyKeyboardMarkup::Pt
 KeyboardButton::Ptr TgTypeParser::parseJsonAndGetKeyboardButton(const boost::property_tree::ptree& data) const {
     auto result(std::make_shared<KeyboardButton>());
     result->text = data.get<std::string>("text", "");
+    result->requestUser = tryParseJson<KeyboardButtonRequestUser>(&TgTypeParser::parseJsonAndGetKeyboardButtonRequestUser, data, "request_user");
+    result->requestChat = tryParseJson<KeyboardButtonRequestChat>(&TgTypeParser::parseJsonAndGetKeyboardButtonRequestChat, data, "request_chat");
     result->requestContact = data.get<bool>("request_contact", false);
     result->requestLocation = data.get<bool>("request_location", false);
     result->requestPoll = tryParseJson<KeyboardButtonPollType>(&TgTypeParser::parseJsonAndGetKeyboardButtonPollType, data, "request_poll");
@@ -1269,10 +1315,66 @@ std::string TgTypeParser::parseKeyboardButton(const KeyboardButton::Ptr& object)
     std::string result;
     result += '{';
     appendToJson(result, "text", object->text);
+    appendToJson(result, "request_user", parseKeyboardButtonRequestUser(object->requestUser));
+    appendToJson(result, "request_chat", parseKeyboardButtonRequestChat(object->requestChat));
     appendToJson(result, "request_contact", object->requestContact);
     appendToJson(result, "request_location", object->requestLocation);
     appendToJson(result, "request_poll", parseKeyboardButtonPollType(object->requestPoll));
     appendToJson(result, "web_app", parseWebAppInfo(object->webApp));
+    removeLastComma(result);
+    result += '}';
+    return result;
+}
+
+KeyboardButtonRequestUser::Ptr TgTypeParser::parseJsonAndGetKeyboardButtonRequestUser(const boost::property_tree::ptree& data) const {
+    auto result(std::make_shared<KeyboardButtonRequestUser>());
+    result->requestId = data.get<std::int32_t>("request_id", 0);
+    result->userIsBot = data.get<bool>("user_is_bot", false);
+    result->userIsPremium = data.get<bool>("user_is_premium", false);
+    return result;
+}
+
+std::string TgTypeParser::parseKeyboardButtonRequestUser(const KeyboardButtonRequestUser::Ptr& object) const {
+    if (!object) {
+        return "";
+    }
+    std::string result;
+    result += '{';
+    appendToJson(result, "request_id", object->requestId);
+    appendToJson(result, "user_is_bot", object->userIsBot);
+    appendToJson(result, "user_is_premium", object->userIsPremium);
+    removeLastComma(result);
+    result += '}';
+    return result;
+}
+
+KeyboardButtonRequestChat::Ptr TgTypeParser::parseJsonAndGetKeyboardButtonRequestChat(const boost::property_tree::ptree& data) const {
+    auto result(std::make_shared<KeyboardButtonRequestChat>());
+    result->requestId = data.get<std::int32_t>("request_id", 0);
+    result->chatIsChannel = data.get<bool>("chat_is_channel", false);
+    result->chatIsForum = data.get<bool>("chat_is_forum", false);
+    result->chatHasUsername = data.get<bool>("chat_has_username", false);
+    result->chatIsCreated = data.get<bool>("chat_is_created", false);
+    result->userAdministratorRights = tryParseJson<ChatAdministratorRights>(&TgTypeParser::parseJsonAndGetChatAdministratorRights, data, "user_administrator_rights");
+    result->botAdministratorRights = tryParseJson<ChatAdministratorRights>(&TgTypeParser::parseJsonAndGetChatAdministratorRights, data, "bot_administrator_rights");
+    result->botIsMember = data.get<bool>("bot_is_member", false);
+    return result;
+}
+
+std::string TgTypeParser::parseKeyboardButtonRequestChat(const KeyboardButtonRequestChat::Ptr& object) const {
+    if (!object) {
+        return "";
+    }
+    std::string result;
+    result += '{';
+    appendToJson(result, "request_id", object->requestId);
+    appendToJson(result, "chat_is_channel", object->chatIsChannel);
+    appendToJson(result, "chat_is_forum", object->chatIsForum);
+    appendToJson(result, "chat_has_username", object->chatHasUsername);
+    appendToJson(result, "chat_is_created", object->chatIsCreated);
+    appendToJson(result, "user_administrator_rights", parseChatAdministratorRights(object->userAdministratorRights));
+    appendToJson(result, "bot_administrator_rights", parseChatAdministratorRights(object->botAdministratorRights));
+    appendToJson(result, "bot_is_member", object->botIsMember);
     removeLastComma(result);
     result += '}';
     return result;
@@ -1693,15 +1795,20 @@ ChatMemberRestricted::Ptr TgTypeParser::parseJsonAndGetChatMemberRestricted(cons
     // NOTE: This function will be called by parseJsonAndGetChatMember().
     auto result(std::make_shared<ChatMemberRestricted>());
     result->isMember = data.get<bool>("is_member", false);
+    result->canSendMessages = data.get<bool>("can_send_messages", false);
+    result->canSendAudios = data.get<bool>("can_send_audios", false);
+    result->canSendDocuments = data.get<bool>("can_send_documents", false);
+    result->canSendPhotos = data.get<bool>("can_send_photos", false);
+    result->canSendVideos = data.get<bool>("can_send_videos", false);
+    result->canSendVideoNotes = data.get<bool>("can_send_video_notes", false);
+    result->canSendVoiceNotes = data.get<bool>("can_send_voice_notes", false);
+    result->canSendPolls = data.get<bool>("can_send_polls", false);
+    result->canSendOtherMessages = data.get<bool>("can_send_other_messages", false);
+    result->canAddWebPagePreviews = data.get<bool>("can_add_web_page_previews", false);
     result->canChangeInfo = data.get<bool>("can_change_info", false);
     result->canInviteUsers = data.get<bool>("can_invite_users", false);
     result->canPinMessages = data.get<bool>("can_pin_messages", false);
     result->canManageTopics = data.get<bool>("can_manage_topics", false);
-    result->canSendMessages = data.get<bool>("can_send_messages", false);
-    result->canSendMediaMessages = data.get<bool>("can_send_media_messages", false);
-    result->canSendPolls = data.get<bool>("can_send_polls", false);
-    result->canSendOtherMessages = data.get<bool>("can_send_other_messages", false);
-    result->canAddWebPagePreviews = data.get<bool>("can_add_web_page_previews", false);
     result->untilDate = data.get<std::uint32_t>("until_date", 0);
     return result;
 }
@@ -1714,15 +1821,20 @@ std::string TgTypeParser::parseChatMemberRestricted(const ChatMemberRestricted::
     // curly brackets to the result std::string.
     std::string result;
     appendToJson(result, "is_member", object->isMember);
+    appendToJson(result, "can_send_messages", object->canSendMessages);
+    appendToJson(result, "can_send_audios", object->canSendAudios);
+    appendToJson(result, "can_send_documents", object->canSendDocuments);
+    appendToJson(result, "can_send_photos", object->canSendPhotos);
+    appendToJson(result, "can_send_videos", object->canSendVideos);
+    appendToJson(result, "can_send_video_notes", object->canSendVideoNotes);
+    appendToJson(result, "can_send_voice_notes", object->canSendVoiceNotes);
+    appendToJson(result, "can_send_polls", object->canSendPolls);
+    appendToJson(result, "can_send_other_messages", object->canSendOtherMessages);
+    appendToJson(result, "can_add_web_page_previews", object->canAddWebPagePreviews);
     appendToJson(result, "can_change_info", object->canChangeInfo);
     appendToJson(result, "can_invite_users", object->canInviteUsers);
     appendToJson(result, "can_pin_messages", object->canPinMessages);
     appendToJson(result, "can_manage_topics", object->canManageTopics);
-    appendToJson(result, "can_send_messages", object->canSendMessages);
-    appendToJson(result, "can_send_media_messages", object->canSendMediaMessages);
-    appendToJson(result, "can_send_polls", object->canSendPolls);
-    appendToJson(result, "can_send_other_messages", object->canSendOtherMessages);
-    appendToJson(result, "can_add_web_page_previews", object->canAddWebPagePreviews);
     appendToJson(result, "until_date", object->untilDate);
     // The last comma will be erased by parseChatMember().
     return result;
@@ -1796,6 +1908,7 @@ ChatJoinRequest::Ptr TgTypeParser::parseJsonAndGetChatJoinRequest(const boost::p
     auto result(std::make_shared<ChatJoinRequest>());
     result->chat = tryParseJson<Chat>(&TgTypeParser::parseJsonAndGetChat, data, "chat");
     result->from = tryParseJson<User>(&TgTypeParser::parseJsonAndGetUser, data, "from");
+    result->userChatId = data.get<std::int64_t>("user_chat_id", 0);
     result->date = data.get<std::int32_t>("date", 0);
     result->bio = data.get<std::string>("bio", "");
     result->inviteLink = tryParseJson<ChatInviteLink>(&TgTypeParser::parseJsonAndGetChatInviteLink, data, "invite_link");
@@ -1810,6 +1923,7 @@ std::string TgTypeParser::parseChatJoinRequest(const ChatJoinRequest::Ptr& objec
     result += '{';
     appendToJson(result, "chat", parseChat(object->chat));
     appendToJson(result, "from", parseUser(object->from));
+    appendToJson(result, "user_chat_id", object->userChatId);
     appendToJson(result, "date", object->date);
     appendToJson(result, "bio", object->bio);
     appendToJson(result, "invite_link", parseChatInviteLink(object->inviteLink));
@@ -1821,7 +1935,12 @@ std::string TgTypeParser::parseChatJoinRequest(const ChatJoinRequest::Ptr& objec
 ChatPermissions::Ptr TgTypeParser::parseJsonAndGetChatPermissions(const boost::property_tree::ptree& data) const {
     auto result(std::make_shared<ChatPermissions>());
     result->canSendMessages = data.get<bool>("can_send_messages", false);
-    result->canSendMediaMessages = data.get<bool>("can_send_media_messages", false);
+    result->canSendAudios = data.get<bool>("can_send_audios", false);
+    result->canSendDocuments = data.get<bool>("can_send_documents", false);
+    result->canSendPhotos = data.get<bool>("can_send_photos", false);
+    result->canSendVideos = data.get<bool>("can_send_videos", false);
+    result->canSendVideoNotes = data.get<bool>("can_send_video_notes", false);
+    result->canSendVoiceNotes = data.get<bool>("can_send_voice_notes", false);
     result->canSendPolls = data.get<bool>("can_send_polls", false);
     result->canSendOtherMessages = data.get<bool>("can_send_other_messages", false);
     result->canAddWebPagePreviews = data.get<bool>("can_add_web_page_previews", false);
@@ -1839,7 +1958,12 @@ std::string TgTypeParser::parseChatPermissions(const ChatPermissions::Ptr& objec
     std::string result;
     result += '{';
     appendToJson(result, "can_send_messages", object->canSendMessages);
-    appendToJson(result, "can_send_media_messages", object->canSendMediaMessages);
+    appendToJson(result, "can_send_audios", object->canSendAudios);
+    appendToJson(result, "can_send_documents", object->canSendDocuments);
+    appendToJson(result, "can_send_photos", object->canSendPhotos);
+    appendToJson(result, "can_send_videos", object->canSendVideos);
+    appendToJson(result, "can_send_video_notes", object->canSendVideoNotes);
+    appendToJson(result, "can_send_voice_notes", object->canSendVoiceNotes);
     appendToJson(result, "can_send_polls", object->canSendPolls);
     appendToJson(result, "can_send_other_messages", object->canSendOtherMessages);
     appendToJson(result, "can_add_web_page_previews", object->canAddWebPagePreviews);


### PR DESCRIPTION
- Added the class KeyboardButtonRequestUser and the field requestUser to the class KeyboardButton.
- Added the class KeyboardButtonRequestChat and the field requestChat to the class KeyboardButton.
- Added the classes UserShared, ChatShared and the fields userShared, and chatShared to the class Message.
- Replaced the fields canSendMediaMessages in the classes ChatMemberRestricted and ChatPermissions with separate fields canSendAudios, canSendDocuments, canSendPhotos, canSendVideos, canSendVideoNotes, and canSendVoiceNotes for different media types.
- Added the parameter useIndependentChatPermissions to the methods restrictChatMember and setChatPermissions.
- Added the field userChatId to the class ChatJoinRequest.