### PR TITLE
Added ability to handle error codes from all Api requests

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -1989,7 +1989,7 @@ public:
 
     const HttpClient& _httpClient;
     
-private:
+protected:
     boost::property_tree::ptree sendRequest(const std::string& method, const std::vector<HttpReqArg>& args = std::vector<HttpReqArg>()) const;
 
     const std::string _token;

--- a/include/tgbot/TgException.h
+++ b/include/tgbot/TgException.h
@@ -16,7 +16,21 @@ namespace TgBot {
 class TGBOT_API TgException : public std::runtime_error {
 
 public:
-    explicit TgException(const std::string& description);
+
+    /**
+     * @brief Enum of possible errors from Api requests 
+     */
+    enum class ErrorCode : size_t {
+        Undefined = 0,
+        BadRequest = 400, Unauthorized = 401, 
+        Forbidden = 403, NotFound = 404, 
+        Flood = 402, Internal = 500,
+        HtmlResponse = 100, InvalidJson = 101
+    };
+
+    explicit TgException(const std::string& description, ErrorCode errorCode);
+
+    const ErrorCode errorCode;
 };
 
 }

--- a/src/TgException.cpp
+++ b/src/TgException.cpp
@@ -4,7 +4,9 @@
 
 namespace TgBot {
 
-TgBot::TgException::TgException(const std::string& description) : runtime_error(description) {
+TgException::TgException(const std::string& description, ErrorCode errorCode) 
+        : runtime_error(description), errorCode(errorCode)
+{
 }
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SRC_LIST
     main.cpp
+    tgbot/Api.cpp
     tgbot/net/Url.cpp
     tgbot/net/HttpParser.cpp
     tgbot/tools/StringTools.cpp

--- a/test/tgbot/Api.cpp
+++ b/test/tgbot/Api.cpp
@@ -1,0 +1,64 @@
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "tgbot/net/HttpClient.h"
+#include "tgbot/Api.h"
+#include "tgbot/TgException.h"
+
+using namespace std;
+using namespace TgBot;
+
+typedef TgException::ErrorCode TgErrorCode;
+
+class TestableApi : public Api {
+public:
+    using Api::Api;
+    using Api::sendRequest;
+};
+
+class HttpClientMock : public HttpClient {
+public:
+    std::string makeRequest(const Url& url, const std::vector<HttpReqArg>& args) const override 
+    {return response;};
+
+    int getRequestMaxRetries() const override { return 0;};
+    int getRequestBackoff() const override {return 1;};
+
+    string response;
+};
+
+bool Request(TgErrorCode expectedCode, const string& response) {
+    HttpClientMock httpClientMock;
+    httpClientMock.response = response;
+
+    TestableApi api("token", httpClientMock, "url");
+
+    try {
+        api.sendRequest("", vector<HttpReqArg>());
+    } catch (TgException& exception) {
+        return exception.errorCode == expectedCode;
+    }
+
+    return false;
+}
+
+BOOST_AUTO_TEST_SUITE(tApi)
+
+BOOST_AUTO_TEST_CASE(sendRequest) {
+    BOOST_CHECK(Request(TgErrorCode::HtmlResponse, "<html>"));
+    BOOST_CHECK(Request(TgErrorCode::Undefined, "{\"ok\": false}"));
+    BOOST_CHECK(Request(TgErrorCode::Undefined, "{\"ok\": false, \"error_code\":0}"));
+
+    BOOST_CHECK(Request(TgErrorCode::BadRequest, "{\"ok\": false, \"error_code\":400}"));
+    BOOST_CHECK(Request(TgErrorCode::Unauthorized, "{\"ok\": false, \"error_code\":401}"));
+    BOOST_CHECK(Request(TgErrorCode::Forbidden, "{\"ok\": false, \"error_code\":403}"));
+    BOOST_CHECK(Request(TgErrorCode::NotFound, "{\"ok\": false, \"error_code\":404}"));
+    BOOST_CHECK(Request(TgErrorCode::Flood, "{\"ok\": false, \"error_code\":402}"));
+    BOOST_CHECK(Request(TgErrorCode::Internal, "{\"ok\": false, \"error_code\":500}"));
+
+    BOOST_CHECK(Request(TgErrorCode::InvalidJson, "error_code:101"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
As a **_programmer_** i want to have ability get **_error code_** from failed sendMessage and etc methods. This functionality can help identify **_peoples_** who **_ban_** bot.