### PR TITLE
Fix keyboard markup type in exditmessagetext

### DIFF
--- a/include/tgbot/Api.h
+++ b/include/tgbot/Api.h
@@ -1473,7 +1473,7 @@ public:
                                  const std::string& inlineMessageId = "",
                                  const std::string& parseMode = "",
                                  bool disableWebPagePreview = false,
-                                 GenericReply::Ptr replyMarkup = nullptr,
+                                 InlineKeyboardMarkup::Ptr replyMarkup = nullptr,
                                  const std::vector<MessageEntity::Ptr>& entities = std::vector<MessageEntity::Ptr>()) const;
 
     /**

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1776,7 +1776,7 @@ Message::Ptr Api::editMessageText(const std::string& text,
                                   const std::string& inlineMessageId,
                                   const std::string& parseMode,
                                   bool disableWebPagePreview,
-                                  GenericReply::Ptr replyMarkup,
+                                  InlineKeyboardMarkup::Ptr replyMarkup,
                                   const std::vector<MessageEntity::Ptr>& entities) const {
     std::vector<HttpReqArg> args;
     args.reserve(8);


### PR DESCRIPTION
Fix #297

This PR fixes the mentioned issue. Just changed data types in couple of places. It looked like those were the only places where change was needed.