### PR TITLE
Avoid unnecessary casting of reply_markup in editMessageText

### DIFF
--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1801,7 +1801,7 @@ Message::Ptr Api::editMessageText(const std::string& text,
         args.emplace_back("disable_web_page_preview", disableWebPagePreview);
     }
     if (replyMarkup) {
-        args.emplace_back("reply_markup", _tgTypeParser.parseGenericReply(replyMarkup));
+        args.emplace_back("reply_markup", _tgTypeParser.parseInlineKeyboardMarkup(replyMarkup));
     }
 
     boost::property_tree::ptree p = sendRequest("editMessageText", args);


### PR DESCRIPTION
These change should have been part of #298 PR. I didn't know there was separate method to parse InlineKeyboardMarkup. Upon closer look I noticed editMessageText was calling a generic method which does casting to  determine exact keyboard type and then in turn calls another method for parsing the determined type.

Now that we are using inline keyboard specifically, all that is unnecessary. So this one line change bypasses that and its more appropriate.

Sorry for submitting incomplete PR. This should be complete now.