### PR TITLE
Allow curl handle in `CurlHttpClient` to be kept alive

### DIFF
--- a/include/tgbot/net/CurlHttpClient.h
+++ b/include/tgbot/net/CurlHttpClient.h
@@ -10,8 +10,11 @@
 
 #include <curl/curl.h>
 
+#include <mutex>
 #include <string>
 #include <vector>
+#include <thread>
+#include <unordered_map>
 
 namespace TgBot {
 
@@ -35,9 +38,14 @@ public:
     std::string makeRequest(const Url& url, const std::vector<HttpReqArg>& args) const override;
 
     /**
-     * @brief Raw curl settings storage for fine tuning.
+     * @brief Raw curl handles, each thread has its own handle.
      */
-    CURL* curlSettings;
+    std::unordered_map<std::thread::id, CURL*> curlHandles;
+
+    /**
+     * @brief Lock for curlHandles access.
+     */
+    std::mutex curlHandlesMutex;
 
 private:
     const HttpParser _httpParser;


### PR DESCRIPTION
Thank you so much for this amazing library!

# Improvement Proposal
The `CurlHttpClient` currently produces an excessive number of `connect()` syscalls, as every `makeRequest` creates a new TCP connection. This inefficiency becomes particularly evident with `TgLongPoll`, which continuously calls `getUpdates` in an endless loop, creating a relentless cycle of `connect()` and `close()` operations.

A more sensible approach is to reuse HTTP connections by keeping them alive across multiple requests. I suggest modifying the implementation to allow the curl handle to persist until the `CurlHttpClient` object is destroyed.

For thread safety, we can maintain a `std::unordered_map<std::thread::id, CURL*> curlHandles` within the `CurlHttpClient` class, ensuring each thread gets its own handle.

After all, treating connections like disposable napkins doesn't exactly scream efficiency.

# Before this change
So many socket `connect()` and `close()` calls:
```
ammarfaizi2@integral2:~/p/ict-bot/build$ strace -e connect ./ict-bot
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2001:67c:4e8:f004::9", &sin6_addr), sin6_scope_id=0}, 28) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2001:67c:4e8:f004::9", &sin6_addr), sin6_scope_id=0}, 28) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2001:67c:4e8:f004::9", &sin6_addr), sin6_scope_id=0}, 28) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2001:67c:4e8:f004::9", &sin6_addr), sin6_scope_id=0}, 28) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
connect(9, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
```

# After this change
Connect once, use it as long as possible:
```
ammarfaizi2@integral2:~/p/ict-bot/build$ strace -e connect ./ict-bot
connect(7, {sa_family=AF_INET, sin_port=htons(443), sin_addr=inet_addr("149.154.167.220")}, 16) = -1 EINPROGRESS (Operation now in progress)
```
