### PR TITLE
[GIT PULL] net: CurlHttpClient: Call `curl_easy_reset()` to fix error 'rewinding of the data'

### DIFF
--- a/src/net/CurlHttpClient.cpp
+++ b/src/net/CurlHttpClient.cpp
@@ -28,8 +28,6 @@ static CURL* getCurlHandle(const CurlHttpClient *c_) {
         if (!curl) {
             throw std::runtime_error("curl_easy_init() failed");
         }
-        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 20);
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT, c->_timeout);
         c->curlHandles[id] = curl;
         return curl;
     }
@@ -45,6 +43,9 @@ static std::size_t curlWriteString(char* ptr, std::size_t size, std::size_t nmem
 std::string CurlHttpClient::makeRequest(const Url& url, const std::vector<HttpReqArg>& args) const {
     CURL* curl = getCurlHandle(this);
 
+    curl_easy_reset(curl);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 20);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, _timeout);
     std::string u = url.protocol + "://" + url.host + url.path;
     if (args.empty()) {
         u += "?" + url.query;


### PR DESCRIPTION
Hi @reo7sp,

Please consider pulling a single line change to fix a bug in the curl netlib.

@okman334 reported an error when using the curl HTTP client after commit
775291f5e4d ("net: Allow curl handle in CurlHttpClient to be kept alive"):

   error: curl error: Send failed since rewinding of the data stream failed.

Fix this by calling `curl_easy_reset()` before setting curl options. It
reinitializes all options previously set on a specified curl handle to
the default values while keeping the connection alive.

This pull request will close issue #340 once merged.

Thank you!

```
The following changes since commit 84e93a11803dbaecbb41cf87f069a893ff779de1:

  Merge pull request #338 from Makcal/patch-1 (2025-07-01 11:49:02 +0300)

are available in the Git repository at:

  https://github.com/ammarfaizi2/tgbot-cpp.git tags/fix-curl-netlib

for you to fetch changes up to e6d14baff9f4cdd9c11e17e01541b3107ed75bb7:

  net: CurlHttpClient: Call `curl_easy_reset()` to fix error 'rewinding of the data' (2025-09-06 19:33:35 +0700)

----------------------------------------------------------------
fix-curl-netlib

----------------------------------------------------------------
Ammar Faizi (1):
      net: CurlHttpClient: Call `curl_easy_reset()` to fix error 'rewinding of the data'

 src/net/CurlHttpClient.cpp | 1 +
 1 file changed, 1 insertion(+)
```