### PR TITLE
feat: Add support for message_reaction and message_reaction_count events

### DIFF
--- a/include/tgbot/EventBroadcaster.h
+++ b/include/tgbot/EventBroadcaster.h
@@ -12,6 +12,8 @@
 #include "tgbot/types/PollAnswer.h"
 #include "tgbot/types/ChatMemberUpdated.h"
 #include "tgbot/types/ChatJoinRequest.h"
+#include "tgbot/types/MessageReactionUpdated.h"
+#include "tgbot/types/MessageReactionCountUpdated.h"
 #include "tgbot/types/SuccessfulPayment.h"
 
 #include <functional>
@@ -44,6 +46,8 @@ public:
     typedef std::function<void (const PollAnswer::Ptr)> PollAnswerListener;
     typedef std::function<void (const ChatMemberUpdated::Ptr)> ChatMemberUpdatedListener;
     typedef std::function<void (const ChatJoinRequest::Ptr)> ChatJoinRequestListener;
+    typedef std::function<void (const MessageReactionUpdated::Ptr)> MessageReactionUpdatedListener;
+    typedef std::function<void (const MessageReactionCountUpdated::Ptr)> MessageReactionCountUpdatedListener;
     typedef std::function<void (const Message::Ptr, const SuccessfulPayment::Ptr)> SuccessfulPaymentListener;
 
     /**
@@ -205,6 +209,22 @@ public:
     }
 
     /**
+     * @brief Registers listener which receives new incoming message reaction update event.
+     * @param listener Listener.
+     */
+    inline void onMessageReaction(const MessageReactionUpdatedListener& listener) {
+        _onMessageReactionUpdatedListener.push_back(listener);
+    }
+
+    /**
+     * @brief Registers listener which receives new incoming message reaction count update event.
+     * @param listener Listener.
+     */
+    inline void onMessageReactionCount(const MessageReactionCountUpdatedListener& listener) {
+        _onMessageReactionCountUpdatedListener.push_back(listener);
+    }
+
+    /**
     * @brief Registers listener which receives information about successful payments.
     * This listener is triggered when a successful payment is received by the bot.
     * 
@@ -293,6 +313,14 @@ private:
         broadcast<ChatJoinRequestListener, ChatJoinRequest::Ptr>(_onChatJoinRequestListeners, result);
     }
 
+    inline void broadcastMessageReactionUpdated(const MessageReactionUpdated::Ptr& messageReaction) const {
+        broadcast<MessageReactionUpdatedListener, MessageReactionUpdated::Ptr>(_onMessageReactionUpdatedListener, messageReaction);
+    }
+
+    inline void broadcastMessageReactionCountUpdated(const MessageReactionCountUpdated::Ptr& messageReactionCount) const {
+        broadcast<MessageReactionCountUpdatedListener, MessageReactionCountUpdated::Ptr>(_onMessageReactionCountUpdatedListener, messageReactionCount);
+    }
+
     inline void broadcastSuccessfulPayment(const Message::Ptr& message) const {
         if (!message || !message->successfulPayment) {
             return;
@@ -318,6 +346,8 @@ private:
     std::vector<ChatMemberUpdatedListener> _onMyChatMemberListeners;
     std::vector<ChatMemberUpdatedListener> _onChatMemberListeners;
     std::vector<ChatJoinRequestListener> _onChatJoinRequestListeners;
+    std::vector<MessageReactionUpdatedListener> _onMessageReactionUpdatedListener;
+    std::vector<MessageReactionCountUpdatedListener> _onMessageReactionCountUpdatedListener;
     std::vector<SuccessfulPaymentListener> _onSuccessfulPaymentListeners;
 
 };

--- a/src/EventHandler.cpp
+++ b/src/EventHandler.cpp
@@ -45,6 +45,12 @@ void EventHandler::handleUpdate(const Update::Ptr& update) const {
     if (update->chatJoinRequest != nullptr) {
         _broadcaster.broadcastChatJoinRequest(update->chatJoinRequest);
     }
+    if (update->messageReaction != nullptr) {
+        _broadcaster.broadcastMessageReactionUpdated(update->messageReaction);
+    }
+    if (update->messageReactionCount != nullptr) {
+        _broadcaster.broadcastMessageReactionCountUpdated(update->messageReactionCount);
+    }
 }
 
 void EventHandler::handleMessage(const Message::Ptr& message) const {


### PR DESCRIPTION
## What was done?
Added handling of two types of Telegram Bot API events:
- **message_reaction** - the update represents a change of a reaction on a message performed by a user. [Link](https://core.telegram.org/bots/api#messagereactionupdated).
- **message_reaction_count** - the update represents reaction changes on a message with anonymous reactions. [Link](https://core.telegram.org/bots/api#messagereactioncountupdated).

## Changes
- ✅ Added new classes/structs for `MessageReactionUpdate` and `MessageReactionCountUpdate`
- ✅ Added corresponding event handler methods
- ✅ Added documentation for new methods

## Compatibility
- ✅ Backward compatible changes
- ✅ New functionality is optional

## Why is this important?
Telegram has long since added reactions to messages, and now bots can:
- Track user reactions
- Create interactive interfaces using reactions

Although the latest release version of the library does not allow handling reactions to messages.

## Testing
Testing was performed by a developer using a custom-created bot. The testing included checking for the receipt of the two aforementioned events. The test result was positive. My minor modifications allowed the necessary events to be captured.

It's worth noting that events of the `MessageReactionCountUpdate` type arrive with a significant delay of up to several seconds due to the Telegram Bot API. The API documentation specifically clarifies this effect, which no event handler can affect. [Link](https://core.telegram.org/bots/api#update).

> *The updates are grouped and can be sent with delay up to a few minutes.*

## Links
- Documentation Telegram Bot API: https://core.telegram.org/bots/api

## Checklist
- [x] The code follows the project style
- [x] Documentation updated