### PR TITLE
Fix JSON string-array serialization in TgTypeParser (closes #346)

### DIFF
--- a/include/tgbot/TgTypeParser.h
+++ b/include/tgbot/TgTypeParser.h
@@ -957,6 +957,10 @@ private:
     }
 
     void appendToJson(std::string& json, const std::string& varName, const std::string& value) const;
+
+    /// Appends `"varName":["escapedValue1","escapedValue2",...],` to `json`.
+    /// Does nothing when `values` is empty. Each element is JSON-escaped.
+    void appendStringArrayToJson(std::string& json, const std::string& varName, const std::vector<std::string>& values) const;
 };
 }
 

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -59,7 +59,7 @@ bool Api::setWebhook(const std::string& url,
     if (allowedUpdates != nullptr) {
         auto allowedUpdatesJson = _tgTypeParser.parseArray<std::string>(
             [] (const std::string& s)->std::string {
-            return s;
+            return "\"" + StringTools::escapeJsonString(s) + "\"";
         }, *allowedUpdates);
         args.emplace_back("allowed_updates", allowedUpdatesJson);
     }

--- a/src/TgTypeParser.cpp
+++ b/src/TgTypeParser.cpp
@@ -1,5 +1,7 @@
 #include "tgbot/TgTypeParser.h"
 
+#include "tgbot/tools/StringTools.h"
+
 namespace TgBot {
 
 Update::Ptr TgTypeParser::parseJsonAndGetUpdate(const boost::property_tree::ptree& data) const {
@@ -97,10 +99,7 @@ std::string TgTypeParser::parseWebhookInfo(const WebhookInfo::Ptr& object) const
     appendToJson(result, "last_error_message", object->lastErrorMessage);
     appendToJson(result, "last_synchronization_error_date", object->lastSynchronizationErrorDate);
     appendToJson(result, "max_connections", object->maxConnections);
-    appendToJson(result, "allowed_updates", parseArray<std::string>(
-        [] (const std::string& s)->std::string {
-        return s;
-    }, object->allowedUpdates));
+    appendStringArrayToJson(result, "allowed_updates", object->allowedUpdates);
     removeLastComma(result);
     result += '}';
     return result;
@@ -227,10 +226,7 @@ std::string TgTypeParser::parseChat(const Chat::Ptr& object) const {
     appendToJson(result, "last_name", object->lastName);
     appendToJson(result, "is_forum", object->isForum);
     appendToJson(result, "photo", parseChatPhoto(object->photo));
-    appendToJson(result, "active_usernames", parseArray<std::string>(
-        [] (const std::string& s)->std::string {
-        return s;
-    }, object->activeUsernames));
+    appendStringArrayToJson(result, "active_usernames", object->activeUsernames);
     appendToJson(result, "birthdate", parseBirthdate(object->birthdate));
     appendToJson(result, "business_intro", parseBusinessIntro(object->businessIntro));
     appendToJson(result, "business_location", parseBusinessLocation(object->businessLocation));
@@ -1650,10 +1646,7 @@ std::string TgTypeParser::parseGiveaway(const Giveaway::Ptr& object) const {
     appendToJson(result, "only_new_members", object->onlyNewMembers);
     appendToJson(result, "has_public_winners", object->hasPublicWinners);
     appendToJson(result, "prize_description", object->prizeDescription);
-    appendToJson(result, "country_codes", parseArray<std::string>(
-        [] (const std::string& s)->std::string {
-        return s;
-    }, object->countryCodes));
+    appendStringArrayToJson(result, "country_codes", object->countryCodes);
     appendToJson(result, "premium_subscription_month_count", object->premiumSubscriptionMonthCount);
     removeLastComma(result);
     result += '}';
@@ -3819,15 +3812,9 @@ std::string TgTypeParser::parseInputSticker(const InputSticker::Ptr& object) con
     result += '{';
     appendToJson(result, "sticker", object->sticker);
     appendToJson(result, "format", object->format);
-    appendToJson(result, "emoji_list", parseArray<std::string>(
-        [] (const std::string& s)->std::string {
-        return s;
-    }, object->emojiList));
+    appendStringArrayToJson(result, "emoji_list", object->emojiList);
     appendToJson(result, "mask_position", parseMaskPosition(object->maskPosition));
-    appendToJson(result, "keywords", parseArray<std::string>(
-        [] (const std::string& s)->std::string {
-        return s;
-    }, object->keywords));
+    appendStringArrayToJson(result, "keywords", object->keywords);
     removeLastComma(result);
     result += '}';
     return result;
@@ -5416,10 +5403,7 @@ std::string TgTypeParser::parsePassportElementErrorFiles(const PassportElementEr
     // This function will be called by parsePassportElementError(), so I don't add
     // curly brackets to the result std::string.
     std::string result;
-    appendToJson(result, "file_hashes",
-                 parseArray<std::string>([] (const std::string& s)->std::string {
-        return s;
-    }, object->fileHashes));
+    appendStringArrayToJson(result, "file_hashes", object->fileHashes);
     // The last comma will be erased by parsePassportElementError().
     return result;
 }
@@ -5460,10 +5444,7 @@ std::string TgTypeParser::parsePassportElementErrorTranslationFiles(const Passpo
     // This function will be called by parsePassportElementError(), so I don't add
     // curly brackets to the result std::string.
     std::string result;
-    appendToJson(result, "file_hashes",
-                 parseArray<std::string>([] (const std::string& s)->std::string {
-        return s;
-    }, object->fileHashes));
+    appendStringArrayToJson(result, "file_hashes", object->fileHashes);
     // The last comma will be erased by parsePassportElementError().
     return result;
 }
@@ -5580,6 +5561,24 @@ std::string TgTypeParser::parseGenericReply(const GenericReply::Ptr& object) con
         return parseInlineKeyboardMarkup(std::static_pointer_cast<InlineKeyboardMarkup>(object));
     }
     return "";
+}
+
+void TgTypeParser::appendStringArrayToJson(std::string& json, const std::string& varName, const std::vector<std::string>& values) const {
+    if (values.empty()) {
+        return;
+    }
+    json += '"';
+    json += varName;
+    json += R"(":[)";
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        if (i != 0) {
+            json += ',';
+        }
+        json += '"';
+        json += StringTools::escapeJsonString(values[i]);
+        json += '"';
+    }
+    json += "],";
 }
 
 void TgTypeParser::appendToJson(std::string& json, const std::string& varName, const std::string& value) const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SRC_LIST
     main.cpp
     tgbot/Api.cpp
+    tgbot/TgTypeParser.cpp
     tgbot/net/Url.cpp
     tgbot/net/HttpParser.cpp
     tgbot/tools/StringTools.cpp

--- a/test/tgbot/TgTypeParser.cpp
+++ b/test/tgbot/TgTypeParser.cpp
@@ -1,0 +1,61 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "tgbot/TgTypeParser.h"
+#include "tgbot/types/InputSticker.h"
+
+using namespace std;
+using namespace TgBot;
+
+BOOST_AUTO_TEST_SUITE(tTgTypeParser)
+
+// Regression tests for https://github.com/reo7sp/tgbot-cpp/issues/346 —
+// string arrays were emitted as `[a,b]` (unquoted identifiers) instead of
+// `["a","b"]`, producing invalid JSON and breaking sticker creation.
+
+BOOST_AUTO_TEST_CASE(parseInputStickerEmojiListIsJsonArray) {
+    TgTypeParser parser;
+    auto sticker = make_shared<InputSticker>();
+    sticker->sticker = "file_id_abc";
+    sticker->format = "static";
+    sticker->emojiList = {"smile", "heart"};
+
+    const string json = parser.parseInputSticker(sticker);
+
+    BOOST_CHECK(json.find(R"("emoji_list":["smile","heart"])") != string::npos);
+    // The pre-fix output emitted the array as `[smile,heart]` — assert no regression.
+    BOOST_CHECK(json.find("[smile,heart]") == string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(parseInputStickerEscapesJsonSpecialsInEmoji) {
+    TgTypeParser parser;
+    auto sticker = make_shared<InputSticker>();
+    sticker->sticker = "id";
+    sticker->format = "static";
+    sticker->emojiList = {R"(a"b)", R"(c\d)"};
+
+    const string json = parser.parseInputSticker(sticker);
+
+    BOOST_CHECK(json.find(R"("a\"b")") != string::npos);
+    BOOST_CHECK(json.find(R"("c\\d")") != string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(parseInputStickerOmitsEmptyKeywords) {
+    // Empty arrays should not appear in the output at all, matching the
+    // behaviour of the previous `appendToJson(... parseArray(...))` pattern.
+    TgTypeParser parser;
+    auto sticker = make_shared<InputSticker>();
+    sticker->sticker = "id";
+    sticker->format = "static";
+    sticker->emojiList = {"a"};
+    // keywords is default-constructed empty
+
+    const string json = parser.parseInputSticker(sticker);
+
+    BOOST_CHECK(json.find("keywords") == string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes #346.

### The bug

Seven call sites passed `parseArray<std::string>` an identity lambda:

```cpp
appendToJson(result, "emoji_list", parseArray<std::string>(
    [] (const std::string& s) -> std::string { return s; },  // <- identity
    object->emojiList));
```

The identity lambda produces `[smile,heart]` (unquoted identifiers) instead of `["smile","heart"]`. That's not valid JSON, and @BloodRedTape confirmed in the issue thread that sticker creation is broken because of it. The same pattern exists in `Api::setWebhook` for `allowed_updates`.

### The fix

Added a private helper in `TgTypeParser`:

```cpp
void TgTypeParser::appendStringArrayToJson(std::string& json,
                                           const std::string& varName,
                                           const std::vector<std::string>& values) const;
```

which emits `"name":["escaped","values"],` directly, running each element through `StringTools::escapeJsonString`. It's a no-op when the vector is empty, matching the prior `appendToJson(... parseArray(...))` behaviour.

Replaced the seven broken call sites in `TgTypeParser.cpp`:

- `WebhookInfo.allowed_updates`
- `Chat.active_usernames`
- `Giveaway.country_codes`
- `InputSticker.emoji_list` (the issue's primary reproducer)
- `InputSticker.keywords`
- `PassportElementErrorFiles.file_hashes`
- `PassportElementErrorTranslationFiles.file_hashes`

And fixed the single analogous site in `Api::setWebhook` by aligning its lambda with the pattern the other `Api.cpp` string-array sites already use (`return "\"" + StringTools::escapeJsonString(s) + "\""`).

### What I did NOT change

I initially experimented with widening `appendToJson(std::string)`'s bracket heuristic to recognise `[...]` as pre-serialized JSON — this would have also fixed latent bugs in other array-wrapping call sites (e.g. `parseMessage`'s `entities`). I reverted that because it would regress any field whose value legitimately starts with `[` and ends with `]` (keyboard-button text like `"[CLICK]"`, captions, etc.). A dedicated helper is safer.

Only paths actually used by real Bot API requests are affected by this fix (`setWebhook`, `createNewStickerSet`/`addStickerToSet` via `parseInputSticker`, `answerInlineQuery` via the passport-error serializers).

### Testing

Added `test/tgbot/TgTypeParser.cpp` with three regression tests:

- `parseInputStickerEmojiListIsJsonArray` — asserts the output contains `"emoji_list":["smile","heart"]` and not the pre-fix `[smile,heart]`.
- `parseInputStickerEscapesJsonSpecialsInEmoji` — asserts inner `"` and `\` get properly JSON-escaped.
- `parseInputStickerOmitsEmptyKeywords` — preserves prior behaviour where empty arrays are omitted from the output entirely.

Local build (Boost 1.90, OpenSSL 3.6, clang 17 on macOS arm64):

```
$ ./test/TgBot_test
Running 18 test cases...
*** No errors detected
```

(15 pre-existing + 3 new, all passing.)

Also verified end-to-end with a small smoke test:

```
Before: {"sticker":"file_id","format":"static","emoji_list":"[smile,heart]"}
After:  {"sticker":"file_id","format":"static","emoji_list":["smile","heart"]}
```